### PR TITLE
Make activities on same day chronologically ordered

### DIFF
--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -83,7 +83,7 @@ module Friends
       activity.description ||= Readline.readline(activity.display_text)
 
       activity.highlight_friends(introvert: self)
-      @activities << activity
+      @activities.unshift(activity)
       clean # Write a cleaned file.
 
       activity # Return the added activity.

--- a/test/introvert_spec.rb
+++ b/test/introvert_spec.rb
@@ -236,7 +236,15 @@ describe Friends::Introvert do
     it "adds the given activity" do
       stub_friends(friends) do
         subject
-        introvert.activities.last.description.must_equal activity_description
+        introvert.activities.first.description.must_equal activity_description
+      end
+    end
+
+    it "adds the activity after others on the same day" do
+      stub_friends(friends) do
+        introvert.add_activity(serialization: "2014-01-01: Ate breakfast.")
+        subject
+        introvert.activities.first.description.must_equal activity_description
       end
     end
 


### PR DESCRIPTION
Previously, two activities listed on the same day would be saved to
the friends.md file in the reverse order of their writing, which
anecdotally is not the order in which they make the most sense.

This commit changes the behavior, so if one adds the activities:
"2016-01-01: Got breakfast."
"2016-01-01: Got lunch."

The lunch activity will appear as "later" than the breakfast one
when listing activities.

This resolves #37.