### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ quickly. And if you'd like to do the implementing yourself:
 
 **Make sure your changes have appropriate tests (`rake test`) and
 conform to the Rubocop style specified. This project uses
-[overcommit](https://github.com/causes/overcommit) to enforce good
+[overcommit](https://github.com/brigade/overcommit) to enforce good
 code.**
 
 ## License


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/causes/overcommit | https://github.com/brigade/overcommit 
