### PR TITLE
Fix `suggest` command for low number of friends

### DIFF
--- a/bin/friends
+++ b/bin/friends
@@ -159,10 +159,11 @@ command :suggest do |suggest|
     suggestions = @introvert.suggest
 
     puts "Distant friend: "\
-      "#{Paint[suggestions[:distant].sample, :bold, :magenta]}"
+      "#{Paint[suggestions[:distant].sample || 'None found', :bold, :magenta]}"
     puts "Moderate friend: "\
-      "#{Paint[suggestions[:moderate].sample, :bold, :magenta]}"
-    puts "Close friend: #{Paint[suggestions[:close].sample, :bold, :magenta]}"
+      "#{Paint[suggestions[:moderate].sample || 'None found', :bold, :magenta]}"
+    puts "Close friend: "\
+      "#{Paint[suggestions[:close].sample || 'None found', :bold, :magenta]}"
   end
 end
 

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -188,8 +188,12 @@ module Friends
 
       output = Hash.new { |h, k| h[k] = [] }
 
+      # Set initial value in case there are no friends and the while loop is
+      # never entered.
+      output[:distant] = []
+
       # First, get not-so-good friends.
-      while sorted_friends.first.n_activities < 2
+      while !sorted_friends.empty? && sorted_friends.first.n_activities < 2
         output[:distant] << sorted_friends.shift.name
       end
 

--- a/test/introvert_spec.rb
+++ b/test/introvert_spec.rb
@@ -300,6 +300,18 @@ describe Friends::Introvert do
         end
       end
     end
+
+    it "doesn't choke when there are no friends" do
+      stub_friends([]) do
+        stub_activities([]) do
+          subject.must_equal(
+            distant: [],
+            moderate: [],
+            close: []
+          )
+        end
+      end
+    end
   end
 
   describe "#graph" do


### PR DESCRIPTION
This commit fixes a bug that was causing the `suggest` command
to raise an error when there were not enough friends to meet
its thresholds.

Resolves #44.