### PR TITLE
Add basic nickname support

### DIFF
--- a/bin/friends
+++ b/bin/friends
@@ -35,6 +35,7 @@ switch [:clean],
   negatable: false,
   desc: "Force a clean write of the friends file"
 
+desc "Updates the `friends` program"
 command :update do |update|
   update.action do
     search = `gem search friends`
@@ -126,9 +127,30 @@ command :add do |add|
       @message = "Activity added: \"#{activity.display_text}\""
     end
   end
+
+  add.desc "Adds a nickname to a friend"
+  add.arg_name "NAME NICKNAME"
+  add.command :nickname do |add_nickname|
+    add_nickname.action do |_, _, args|
+      friend = @introvert.add_nickname(name: args.first, nickname: args[1])
+      @message = "Nickname added: \"#{friend}\""
+    end
+  end
 end
 
-desc "Graph"
+desc "Remove a nickname"
+command :remove do |remove|
+  remove.desc "Removes a nickname from a friend"
+  remove.arg_name "NAME NICKNAME"
+  remove.command :nickname do |remove_nickname|
+    remove_nickname.action do |_, _, args|
+      friend = @introvert.remove_nickname(name: args.first, nickname: args[1])
+      @message = "Nickname removed: \"#{friend}\""
+    end
+  end
+end
+
+desc "Graph a friend's relationship over time"
 arg_name "NAME"
 command :graph do |graph|
   graph.action do |_, _, args|
@@ -153,7 +175,7 @@ command :graph do |graph|
   end
 end
 
-desc "Suggest"
+desc "Suggest friends to do activities with"
 command :suggest do |suggest|
   suggest.action do
     suggestions = @introvert.suggest

--- a/friends.md
+++ b/friends.md
@@ -6,5 +6,5 @@
 
 ### Friends:
 - George Washington Carver
-- Grace Hopper
+- Grace Hopper (a.k.a. The Admiral)
 - Marie Curie

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -89,6 +89,35 @@ module Friends
       activity # Return the added activity.
     end
 
+    # Add a nickname to an existing friend and write out the new friends file.
+    # @param name [String] the name of the friend
+    # @param nickname [String] the nickname to add to the friend
+    # @raise [FriendsError] if 0 of 2+ friends match the given name
+    # @return [Friend] the existing friend
+    def add_nickname(name:, nickname:)
+      friend = friend_with_name_in(name)
+      friend.add_nickname(nickname.strip)
+
+      clean # Write a cleaned file.
+
+      friend
+    end
+
+    # Remove a nickname from an existing friend and write out the new friends
+    #   file.
+    # @param name [String] the name of the friend
+    # @param nickname [String] the nickname to remove from the friend
+    # @raise [FriendsError] if 0 of 2+ friends match the given name
+    # @return [Friend] the existing friend
+    def remove_nickname(name:, nickname:)
+      friend = friend_with_name_in(name)
+      friend.remove_nickname(nickname.strip)
+
+      clean # Write a cleaned file.
+
+      friend
+    end
+
     # List all friend names in the friends file.
     # @return [Array] a list of all friend names
     def list_friends
@@ -127,6 +156,7 @@ module Friends
     # @param with [String] the name of a friend to filter by, or nil for
     #   unfiltered
     # @return [Array] a list of all activity text values
+    # @raise [FriendsError] if 0 of 2+ friends match the given `with` text
     def list_activities(limit:, with:)
       acts = @activities
 
@@ -153,6 +183,7 @@ module Friends
     #   The keys of the hash are all of the months (inclusive) between the first
     #   and last month in which activities for the given friend have been
     #   recorded.
+    # @raise [FriendsError] if 0 of 2+ friends match the given name
     def graph(name:)
       friend = friend_with_name_in(name) # Find the friend by name.
 

--- a/test/friend_spec.rb
+++ b/test/friend_spec.rb
@@ -40,6 +40,43 @@ describe Friends::Friend do
     end
   end
 
+  describe "#add_nickname" do
+    subject { friend.add_nickname("The Dude") }
+
+    it "adds the nickname" do
+      subject
+      friend.instance_variable_get(:@nicknames).must_include("The Dude")
+    end
+
+    it "does not keep duplicates" do
+      subject
+      subject
+      friend.instance_variable_get(:@nicknames).must_equal ["The Dude"]
+    end
+  end
+
+  describe "#remove_nickname" do
+    subject { friend.remove_nickname("Jake") }
+
+    describe "when the nickname is present" do
+      let(:friend) do
+        Friends::Friend.new(name: friend_name, nickname_str: "a.k.a. Jake")
+      end
+
+      it "removes the nickname" do
+        friend.instance_variable_get(:@nicknames).must_equal ["Jake"]
+        subject
+        friend.instance_variable_get(:@nicknames).must_equal []
+      end
+    end
+
+    describe "when the nickname is not present" do
+      it "raises an error if the nickname is not found" do
+        proc { subject }.must_raise Friends::FriendsError
+      end
+    end
+  end
+
   describe "#n_activities" do
     subject { friend.n_activities }
 

--- a/test/introvert_spec.rb
+++ b/test/introvert_spec.rb
@@ -255,6 +255,37 @@ describe Friends::Introvert do
     end
   end
 
+  describe "#add_nickname" do
+    subject do
+      introvert.add_nickname(name: friend_names.first, nickname: "The Dude")
+    end
+
+    # Delete the file that is created each time.
+    after { File.delete(filename) if File.exists?(filename) }
+
+    it "returns the modified friend" do
+      stub_friends(friends) do
+        subject.must_equal friends.first
+      end
+    end
+  end
+
+  describe "#remove_nickname" do
+    subject do
+      introvert.remove_nickname(name: "Jeff", nickname: "The Dude")
+    end
+
+    # Delete the file that is created each time.
+    after { File.delete(filename) if File.exists?(filename) }
+
+    it "returns the modified friend" do
+      friend = Friends::Friend.new(name: "Jeff", nickname_str: "a.k.a. The Dude")
+      stub_friends([friend]) do
+        subject.must_equal friend
+      end
+    end
+  end
+
   describe "#list_favorites" do
     subject { introvert.list_favorites(limit: limit) }
 


### PR DESCRIPTION
This change allows users to add nicknames to their
friends via the `add nickname` and `remove nickname`
commands. Friends can have multiple nicknames.

Nicknames are detected in activity text and the
friend's full name is substituted as with normal
partial name substitutions. Only entire nicknames
will be matched for multi-word nicknames.

There is currently no limit on how many friends may
have the same nickname.

Resolves #40.