### PR TITLE
Fix nicknames bug and add README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ $ gem install friends
 ### Basic commands:
 
 ##### Add a friend:
-
 ```
 $ friends add friend "Grace Hopper"
 Friend added: "Grace Hopper"
@@ -64,6 +63,24 @@ You can escape the names of friends you don't want `friends` to match with a bac
 ```
 $ friends add activity "2015-11-01: Grace and I went to \Marie's Diner. \George had to cancel at the last minute."
 Activity added: "2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute."
+```
+##### Set a friend's nicknames:
+```
+$ friends add nickname "Grace Hopper" "The Admiral"
+Nickname added: "Grace Hopper (a.k.a. The Admiral)
+$ friends add nickname "Grace Hopper" "Amazing Grace"
+Nickname added: "Grace Hopper (a.k.a. The Admiral a.k.a. Amazing Grace)"
+```
+Nicknames will be used to match friends in activities,
+just like formal names:
+```
+$ friends add activity "Invented debugging with Amazing Grace.""
+Activity added: "2016-01-06: Invented debugging with Amazing Grace Hopper."
+```
+And they can be removed as well:
+```
+$ friends remove nickname "Grace Hopper" "The Admiral"
+Nickname removed: "Grace Hopper (a.k.a. Amazing Grace)"
 ```
 ##### Suggest a friend to do something with:
 ```

--- a/lib/friends/friend.rb
+++ b/lib/friends/friend.rb
@@ -46,7 +46,7 @@ module Friends
     # @param nickname [String] the nickname to add
     def add_nickname(nickname)
       @nicknames << nickname
-      @nicknames.uniq
+      @nicknames.uniq!
     end
 
     # @param nickname [String] the nickname to remove

--- a/test/friend_spec.rb
+++ b/test/friend_spec.rb
@@ -49,8 +49,10 @@ describe Friends::Friend do
     end
 
     it "does not keep duplicates" do
-      subject
-      subject
+      # Add the same nickname twice. Do not use `subject` because it's memoized.
+      friend.add_nickname("The Dude")
+      friend.add_nickname("The Dude")
+
       friend.instance_variable_get(:@nicknames).must_equal ["The Dude"]
     end
   end


### PR DESCRIPTION
This commit fixes a bug that was preventing nicknames
from being de-duplicated properly when added multiple
times for the same friend.

It also adds documentation on the nicknames feature to
the README.