### PR TITLE
Fix bug in comparing gem versions for update

### DIFF
--- a/bin/friends
+++ b/bin/friends
@@ -8,6 +8,7 @@
 require "gli"
 require "paint"
 require "readline"
+require "semverse"
 
 require "friends/introvert"
 require "friends/version"
@@ -41,7 +42,8 @@ command :update do |update|
     search = `gem search friends`
     if match = search.match(/^friends\s\(([^\)]+)\)$/)
       remote_version = match[1]
-      if remote_version.to_r > Friends::VERSION.to_r
+      if Semverse::Version.coerce(remote_version) >
+         Semverse::Version.coerce(Friends::VERSION)
         `gem update friends && gem cleanup friends`
         if $?.success?
           puts Paint["Updated to friends #{remote_version}", :bold, :green]

--- a/friends.gemspec
+++ b/friends.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gli", "~> 2.12"
   spec.add_dependency "memoist", "~> 0.11"
   spec.add_dependency "paint", "~> 1.0"
+  spec.add_dependency "semverse", "~> 1.2"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0.4"


### PR DESCRIPTION
Previously, gem version comparisons were
done by coercing both values to rational
numbers. This breaks when comparing 0.9 to
0.10, for example (the former is the larger
number but the lower version), so this commit
switches us to use the Semverse gem for this
comparison.

Resolves #72.