### PR TITLE
Update RuboCop and fix many offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ Alias:
   Enabled: false
 
 AllCops:
-  RunRailsCops: false
+  TargetRubyVersion: 2.3
 
 AmbiguousOperator:
   Enabled: false
@@ -149,6 +149,9 @@ MethodLength:
 ModuleFunction:
   Enabled: false
 
+MutableConstant:
+  Enabled: true
+
 NegatedIf:
   Enabled: false
 
@@ -196,6 +199,9 @@ PredicateName:
 Proc:
   Enabled: false
 
+Rails:
+  Enabled: false
+
 RaiseArgs:
   Enabled: false
 
@@ -232,8 +238,11 @@ Style/MultilineBlockChain:
 VariableInterpolation:
   Enabled: false
 
-TrailingComma:
-  Enabled: false
+TrailingCommaInArguments:
+  Enabled: true
+
+TrailingCommaInLiteral:
+  Enabled: true
 
 TrivialAccessors:
   Enabled: false

--- a/bin/friends
+++ b/bin/friends
@@ -24,17 +24,17 @@ subcommand_option_handling :normal
 arguments :strict
 
 switch [:quiet],
-  negatable: false,
-  desc: "Quiet output messages"
+       negatable: false,
+       desc: "Quiet output messages"
 
 flag [:filename],
-  arg_name: "FILENAME",
-  default_value: "./friends.md",
-  desc: "Set the location of the friends file"
+     arg_name: "FILENAME",
+     default_value: "./friends.md",
+     desc: "Set the location of the friends file"
 
 switch [:debug],
-  negatable: false,
-  desc: "Debug error messages with a full backtrace"
+       negatable: false,
+       desc: "Debug error messages with a full backtrace"
 
 desc "Updates the `friends` program"
 command :update do |update|
@@ -71,9 +71,9 @@ command :list do |list|
   list.desc "List favorite friends"
   list.command :favorites do |list_favorites|
     list_favorites.flag [:limit],
-      arg_name: "NUMBER",
-      default_value: 10,
-      desc: "The number of friends to return"
+                        arg_name: "NUMBER",
+                        default_value: 10,
+                        desc: "The number of friends to return"
 
     list_favorites.action do |_, options|
       limit = options[:limit].to_i
@@ -95,13 +95,13 @@ command :list do |list|
   list.desc "Lists all activities"
   list.command :activities do |list_activities|
     list_activities.flag [:limit],
-      arg_name: "NUMBER",
-      default_value: 10,
-      desc: "The number of activities to return"
+                         arg_name: "NUMBER",
+                         default_value: 10,
+                         desc: "The number of activities to return"
 
     list_activities.flag [:with],
-      arg_name: "NAME",
-      desc: "List only activities involving the given friend"
+                         arg_name: "NAME",
+                         desc: "List only activities involving the given friend"
 
     list_activities.action do |_, options|
       limit = options[:limit].to_i
@@ -172,7 +172,7 @@ command :graph do |graph|
 
     colors = (0...(6 * 7)).map do |n|
       n *= 1.0 / 6
-      r  = (3 * Math.sin(n           ) + 3).to_i
+      r  = (3 * Math.sin(n) + 3).to_i
       g  = (3 * Math.sin(n + 2 * PI_3) + 3).to_i
       b  = (3 * Math.sin(n + 4 * PI_3) + 3).to_i
 

--- a/friends.gemspec
+++ b/friends.gemspec
@@ -9,7 +9,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Jacob Evelyn"]
   spec.email         = ["jacobevelyn@gmail.com"]
   spec.summary       = "Spend time with the people you care about."
-  spec.description   = "Spend time with the people you care about. Introvert-tested. Extrovert-approved."
+  spec.description   = "Spend time with the people you care about. "\
+                       "Introvert-tested. Extrovert-approved."
   spec.homepage      = "https://github.com/JacobEvelyn/friends"
   spec.license       = "MIT"
 
@@ -31,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.5"
   spec.add_development_dependency "overcommit", "~> 0.30"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rubocop", "~> 0.35"
+  spec.add_development_dependency "rubocop", "~> 0.36"
 end

--- a/lib/friends/activity.rb
+++ b/lib/friends/activity.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Activity represents an activity you've done with one or more Friends.
 
 require "memoist"
@@ -10,11 +11,14 @@ module Friends
     extend Serializable
     extend Memoist
 
-    SERIALIZATION_PREFIX = "- "
+    SERIALIZATION_PREFIX = "- ".freeze
 
     # @return [Regexp] the regex for capturing groups in deserialization
     def self.deserialization_regex
+      # Note: this regex must be on one line because whitespace is important
+      # rubocop:disable Metrics/LineLength
       /(#{SERIALIZATION_PREFIX})?((?<date_s>\d{4}-\d\d-\d\d)(:\s)?)?(?<description>.+)?/
+      # rubocop:enable Metrics/LineLength
     end
 
     # @return [Regexp] the string of what we expected during deserialization

--- a/lib/friends/friend.rb
+++ b/lib/friends/friend.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Friend represents a friend. You know, a real-life friend!
 
 require "friends/serializable"
@@ -6,12 +7,15 @@ module Friends
   class Friend
     extend Serializable
 
-    SERIALIZATION_PREFIX = "- "
-    NICKNAME_PREFIX = "a.k.a. "
+    SERIALIZATION_PREFIX = "- ".freeze
+    NICKNAME_PREFIX = "a.k.a. ".freeze
 
     # @return [Regexp] the regex for capturing groups in deserialization
     def self.deserialization_regex
+      # Note: this regex must be on one line because whitespace is important
+      # rubocop:disable Metrics/LineLength
       /(#{SERIALIZATION_PREFIX})?(?<name>[^\(]+)(\((?<nickname_str>#{NICKNAME_PREFIX}.+)\))?/
+      # rubocop:enable Metrics/LineLength
     end
 
     # @return [Regexp] the string of what we expected during deserialization
@@ -31,7 +35,7 @@ module Friends
 
     # @return [String] the file serialization text for the friend
     def serialize
-      "#{SERIALIZATION_PREFIX}#{to_s}"
+      "#{SERIALIZATION_PREFIX}#{self}"
     end
 
     # @return [String] a string representing the friend's name and nicknames

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Introvert is the internal handler for the friends script. It is designed to be
 # able to be used directly within another Ruby program, without needing to call
 # the command-line script explicitly.
@@ -8,10 +9,10 @@ require "friends/friends_error"
 
 module Friends
   class Introvert
-    DEFAULT_FILENAME = "./friends.md"
-    ACTIVITIES_HEADER = "### Activities:"
-    FRIENDS_HEADER = "### Friends:"
-    GRAPH_DATE_FORMAT = "%b %Y" # Used as the param for date.strftime().
+    DEFAULT_FILENAME = "./friends.md".freeze
+    ACTIVITIES_HEADER = "### Activities:".freeze
+    FRIENDS_HEADER = "### Friends:".freeze
+    GRAPH_DATE_FORMAT = "%b %Y".freeze # Used as the param for date.strftime().
 
     # @param filename [String] the name of the friends Markdown file
     def initialize(filename: DEFAULT_FILENAME)
@@ -274,13 +275,13 @@ module Friends
     #   description, for instance, is "John Deere" vs. "John Doe"
     def set_likelihood_score!(matches:, possible_matches:)
       combinations = (matches + possible_matches.flatten).
-        combination(2).
-        reject do |friend1, friend2|
-          (matches & [friend1, friend2]).size == 2 ||
-          possible_matches.any? do |group|
-            (group & [friend1, friend2]).size == 2
-          end
-        end
+                     combination(2).
+                     reject do |friend1, friend2|
+                       (matches & [friend1, friend2]).size == 2 ||
+                         possible_matches.any? do |group|
+                           (group & [friend1, friend2]).size == 2
+                         end
+                     end
 
       @activities.each do |activity|
         names = activity.friend_names

--- a/lib/friends/version.rb
+++ b/lib/friends/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Friends
-  VERSION = "0.12"
+  VERSION = "0.12".freeze
 end

--- a/test/introvert_spec.rb
+++ b/test/introvert_spec.rb
@@ -2,8 +2,10 @@ require "./test/helper"
 
 describe Friends::Introvert do
   # Add readers to make internal state easier to test.
-  class Friends::Introvert
-    attr_reader :filename, :activities, :friends
+  module Friends
+    class Introvert
+      attr_reader :filename, :activities, :friends
+    end
   end
 
   # Add helpers to set internal states for friends and activities.
@@ -318,7 +320,8 @@ describe Friends::Introvert do
     after { File.delete(filename) if File.exists?(filename) }
 
     it "returns the modified friend" do
-      friend = Friends::Friend.new(name: "Jeff", nickname_str: "a.k.a. The Dude")
+      friend = Friends::Friend.new(name: "Jeff",
+                                   nickname_str: "a.k.a. The Dude")
       stub_friends([friend]) do
         subject.must_equal friend
       end


### PR DESCRIPTION
Changes are purely for style purposes in accordance to rubocop.yml
settings. These four changes now permit a git commit without skipping
via SKIP=RuboCop.

https://github.com/JacobEvelyn/friends/issues/78