### PR TITLE
Improve handling of double-names and names within names

### DIFF
--- a/bin/friends
+++ b/bin/friends
@@ -40,7 +40,9 @@ desc "Updates the `friends` program"
 command :update do |update|
   update.action do
     search = `gem search friends`
+    # rubocop:disable Lint/AssignmentInCondition
     if match = search.match(/^friends\s\(([^\)]+)\)$/)
+      # rubocop:enable Lint/AssignmentInCondition
       remote_version = match[1]
       if Semverse::Version.coerce(remote_version) >
          Semverse::Version.coerce(Friends::VERSION)

--- a/lib/friends/activity.rb
+++ b/lib/friends/activity.rb
@@ -41,7 +41,9 @@ module Friends
     def display_text
       date_s = Paint[date, :bold]
       description_s = description.to_s
+      # rubocop:disable Lint/AssignmentInCondition
       while match = description_s.match(/(\*\*)([^\*]+)(\*\*)/)
+        # rubocop:enable Lint/AssignmentInCondition
         description_s = "#{match.pre_match}"\
                         "#{Paint[match[2], :bold, :magenta]}"\
                         "#{match.post_match}"
@@ -65,41 +67,31 @@ module Friends
     # more information see the comments below and the
     # introvert#set_likelihood_score! method.
     def highlight_friends(introvert:)
-      friend_regexes = introvert.friend_regex_map
-
-      # Create hash mapping regex to friend. Note that because two friends may
-      # have the same regex (e.g. /John/), we need to store the names in an
-      # array since there may be more than one. We also iterate through the
-      # regexes to add the most important regexes to the hash first, so
-      # "Jacob Evelyn" takes precedence over all instances of "Jacob" (since
-      # Ruby hashes are ordered).
-      regex_map = Hash.new { |h, k| h[k] = [] }
-      while !friend_regexes.empty?
-        friend_regexes.each do |friend, regex_list|
-          regex_map[regex_list.shift] << friend
-          friend_regexes.delete(friend) if regex_list.empty?
-        end
-      end
+      # Split the regex friend map into two maps: one for names with only one
+      # friend match and another for ambiguous names
+      definite_map, ambiguous_map =
+        introvert.regex_friend_map.partition { |_, arr| arr.size == 1 }
 
       matched_friends = []
 
-      # First, we find all of the regex matches with only one possibility, and
-      # make those substitutions.
-      regex_map.
-        select { |_, arr| arr.size == 1 }.each do |regex, friend_list|
-        if @description.match(regex)
+      # First, we find all of the unambiguous matches, and make those
+      # substitutions.
+      definite_map.each do |regex, friend_list|
+        # If we find a match, add the friend to the matched list and replace all
+        # instances of the matching text with the friend's name.
+        description_matches(regex: regex, replace: true) do
           friend = friend_list.first # There's only one friend in the list.
           matched_friends << friend
-          @description.gsub!(regex, "**#{friend.name}**")
+          friend.name
         end
       end
 
       possible_matched_friends = []
 
       # Now, we look at regex matches that are ambiguous.
-      regex_map.
-        reject { |_, arr| arr.size == 1 }.each do |regex, friend_list|
-        if @description.match(regex)
+      ambiguous_map.each do |regex, friend_list|
+        # If we find a match, add the friend to the possible-match list.
+        description_matches(regex: regex, replace: false) do
           possible_matched_friends << friend_list
         end
       end
@@ -111,21 +103,20 @@ module Friends
         possible_matches: possible_matched_friends
       )
 
-      # Now we go through and replace all of the ambiguous matches with our best
-      # guess.
-      regex_map.
-        reject { |_, arr| arr.size == 1 }.each do |regex, friend_list|
-        if @description.match(regex)
-          guessed_friend = friend_list.sort_by do |friend|
+      # Now we replace all of the ambiguous matches with our best guesses.
+      ambiguous_map.each do |regex, friend_list|
+        # If we find a match, take the most likely and replace all instances of
+        # the matching text with that friend's name.
+        description_matches(regex: regex, replace: true) do
+          friend_list.sort_by do |friend|
             [-friend.likelihood_score, -friend.n_activities]
-          end.first
-          @description.gsub!(regex, "**#{guessed_friend.name}**")
+          end.first.name
         end
       end
 
       # Lastly, we remove any backslashes, as these are used to escape friends'
       # names that we don't want to match.
-      @description.delete!("\\")
+      @description = @description.delete("\\")
     end
 
     # Updates a friend's old_name to their new_name
@@ -153,6 +144,45 @@ module Friends
     memoize :friend_names
 
     private
+
+    # This method accepts a block, and tests a regex on the @description
+    # instance variable.
+    # - If the regex does not match, the block is not executed.
+    # - If the regex matches, the block is executed exactly once, and:
+    #   - If `replace` is true, all of the regex's matches are replaced by the
+    #     return value of the block, EXCEPT when the matched text is between a
+    #     set of double-asterisks ("**") indicating it is already part of
+    #     another friend's matched name.
+    #   - If `replace` is not true, we do not modify @description.
+    # @param regex [Regexp] the regex to test against @description
+    # @param replace [Boolean] true iff we should replace regex matches with the
+    #   yielded block's result in @description
+    def description_matches(regex:, replace:)
+      # rubocop:disable Lint/AssignmentInCondition
+      return unless match = @description.match(regex) # Abort if no match.
+      # rubocop:enable Lint/AssignmentInCondition
+      str = yield # It's important to execute the block even if not replacing.
+      return unless replace # Only continue if we want to replace text.
+
+      position = 0 # Prevent infinite looping by tracking last match position.
+      loop do
+        # Only make a replacement if we're not between a set of "**"s.
+        if match.pre_match.scan("**").size % 2 == 0 &&
+           match.post_match.scan("**").size % 2 == 0
+          @description = "#{match.pre_match}**#{str}**#{match.post_match}"
+        else
+          # If we're between double-asterisks we're already part of a name, so
+          # we don't make a substitution. We update `position` to avoid infinite
+          # looping.
+          position = match.end(0)
+        end
+
+        # Exit when there are no more matches.
+        # rubocop:disable Lint/AssignmentInCondition
+        break unless match = @description.match(regex, position)
+        # rubocop:enable Lint/AssignmentInCondition
+      end
+    end
 
     # Default sorting for an array of activities is reverse-date.
     def <=>(other)

--- a/lib/friends/friend.rb
+++ b/lib/friends/friend.rb
@@ -87,13 +87,12 @@ module Friends
       @likelihood_score || 0
     end
 
-    # @return [Array] a list of all regexes to match the name in a string, with
-    #   longer regexes first
-    #   Note: for now we only match on full names or first names
+    # @return [Array] a list of all regexes to match the name in a string
     #   Example: [
     #     /Jacob\s+Morris\s+Evelyn/,
     #     /Jacob/
     #   ]
+    # NOTE: For now we only match on full names or first names.
     def regexes_for_name
       # We generously allow any amount of whitespace between parts of a name.
       splitter = "\\s+"
@@ -104,6 +103,10 @@ module Friends
 
       # We don't want to match names that are directly touching double asterisks
       # as these are treated as sacred by our program.
+      # NOTE: Technically we don't need this check here, since we perform a more
+      # complex asterisk check in the Activity#description_matches method, but
+      # this class shouldn't need to know about the internal implementation of
+      # another class.
       no_leading_asterisks = "(?<!\\*\\*)"
       no_ending_asterisks = "(?!\\*\\*)"
 

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -251,12 +251,15 @@ module Friends
       end
     end
 
-    # @return [Hash] mapping each friend to a list of all possible regexes for
-    #   that friend's name
-    def friend_regex_map
-      @friends.each_with_object({}) do |friend, hash|
-        hash[friend] = friend.regexes_for_name
-      end
+    # @return [Hash] of the form { /regex/ => [list of friends matching regex] }
+    #   This hash is sorted (because Ruby's hashes are ordered) by decreasing
+    #   regex key length, so the key /Jacob Evelyn/ appears before /Jacob/.
+    def regex_friend_map
+      @friends.each_with_object(Hash.new { |h, k| h[k] = [] }) do |friend, hash|
+        friend.regexes_for_name.each do |regex|
+          hash[regex] << friend
+        end
+      end.sort_by { |k, _| -k.to_s.size }.to_h
     end
 
     # Sets the likelihood_score field on each friend in `possible_matches`. This
@@ -278,9 +281,9 @@ module Friends
                      combination(2).
                      reject do |friend1, friend2|
                        (matches & [friend1, friend2]).size == 2 ||
-                         possible_matches.any? do |group|
-                           (group & [friend1, friend2]).size == 2
-                         end
+                       possible_matches.any? do |group|
+                         (group & [friend1, friend2]).size == 2
+                       end
                      end
 
       @activities.each do |activity|

--- a/test/activity_spec.rb
+++ b/test/activity_spec.rb
@@ -135,6 +135,54 @@ describe Friends::Activity do
       end
     end
 
+    describe "when one name ends another after a hyphen" do
+      let(:friend1) { Friends::Friend.new(name: "Mary-Kate Olsen") }
+      let(:friend2) { Friends::Friend.new(name: "Kate Winslet") }
+      let(:description) { "Shopping with Mary-Kate." }
+
+      it "gives precedence to the larger name" do
+        # Make sure "Kate" is a closer friend than "Mary-Kate" so we know our
+        # test result isn't due to chance.
+        friend1.n_activities = 0
+        friend2.n_activities = 10
+
+        subject
+        activity.description.must_equal "Shopping with **Mary-Kate Olsen**."
+      end
+    end
+
+    describe "when one name preceeds another before a hyphen" do
+      let(:friend1) { Friends::Friend.new(name: "Mary-Kate Olsen") }
+      let(:friend2) { Friends::Friend.new(name: "Mary Poppins") }
+      let(:description) { "Shopping with Mary-Kate." }
+
+      it "gives precedence to the larger name" do
+        # Make sure "Kate" is a closer friend than "Mary-Kate" so we know our
+        # test result isn't due to chance.
+        friend1.n_activities = 0
+        friend2.n_activities = 10
+
+        subject
+        activity.description.must_equal "Shopping with **Mary-Kate Olsen**."
+      end
+    end
+
+    describe "when one name is contained within another via a hyphen" do
+      let(:friend1) { Friends::Friend.new(name: "Mary-Jo-Kate Olsen") }
+      let(:friend2) { Friends::Friend.new(name: "Jo Stafford") }
+      let(:description) { "Shopping with Mary-Jo-Kate." }
+
+      it "gives precedence to the larger name" do
+        # Make sure "Kate" is a closer friend than "Mary-Kate" so we know our
+        # test result isn't due to chance.
+        friend1.n_activities = 0
+        friend2.n_activities = 10
+
+        subject
+        activity.description.must_equal "Shopping with **Mary-Jo-Kate Olsen**."
+      end
+    end
+
     describe "when name is at end of word" do
       let(:description) { "Field trip to the JimJohn Co." }
       it "does not match a friend" do


### PR DESCRIPTION
This change improves Activity#highlight_friends' matching to
no longer match friends that are inside one another. For
instance, previously, if we had:

    friends add friend "Billy-Jean-Jim"
    friends add friend "Jean"

    friends add activity "Went fishing with Billy-Jean-Jim."

This would turn into:

    "Went fishing with **Billy-**Jean**-Jim**."

This commit changes our behavior to:

  1. Match friend names in decreasing size order, so Billy-
     Jean-Jim will always match before Jean.
  2. Count asterisk pairs ("**") and only substitute friend
     names when not inside an existing set of asterisk pairs.

Resolves #80.