### PR TITLE
Give nicknames matching precedence over first names

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The `friends.md` Markdown file that stores all of your data contains:
 ```markdown
 ### Friends:
 - George Washington Carver
-- Grace Hopper (a.k.a. The Admiral) [Paris]
+- Grace Hopper (a.k.a. The Admiral a.k.a. Amazing Grace) [Paris]
 - Marie Curie [Atlantis]
 ```
 
@@ -265,6 +265,24 @@ File cleaned: "./friends.md"
 
 This command is useful after manual editing of the file, for re-ordering its
 contents.
+
+#### `edit`
+
+Allows you to manually edit the file:
+
+```bash
+$ friends edit
+Opening "./friends.md" in vim
+```
+
+The file is opened with the command specified by the `$EDITOR` environment
+variable, falling back to `vim` if it is not set:
+
+```bash
+$ export EDITOR=atom
+$ friends edit
+Opening "./friends.md" in atom
+```
 
 #### `graph`
 

--- a/friends.md
+++ b/friends.md
@@ -6,7 +6,7 @@
 
 ### Friends:
 - George Washington Carver
-- Grace Hopper (a.k.a. The Admiral) [Paris]
+- Grace Hopper (a.k.a. The Admiral a.k.a. Amazing Grace) [Paris]
 - Marie Curie [Atlantis]
 
 ### Locations:

--- a/lib/friends/friend.rb
+++ b/lib/friends/friend.rb
@@ -101,7 +101,10 @@ module Friends
 
       # Create the list of regexes and return it.
       chunks = name.split(Regexp.new(splitter))
-      [chunks, [chunks.first], *@nicknames.map { |n| [n] }].map do |words|
+
+      # We check nicknames before first names because nicknames may contain
+      # first names, as in "Amazing Grace" being a nickname for Grace Hopper.
+      [chunks, *@nicknames.map { |n| [n] }, [chunks.first]].map do |words|
         Friends::RegexBuilder.regex(words.join(splitter))
       end
     end

--- a/test/activity_spec.rb
+++ b/test/activity_spec.rb
@@ -173,6 +173,30 @@ describe Friends::Activity do
       end
     end
 
+    describe "when description has nicknames" do
+      let(:description) { "Lunch with Lizzy and Johnny." }
+      it "matches friends" do
+        friend1.add_nickname("Lizzy")
+        friend2.add_nickname("Johnny")
+        subject
+        activity.description.
+          must_equal "Lunch with **#{friend1.name}** and **#{friend2.name}**."
+      end
+    end
+
+    describe "when discription has nicknames which contain first names" do
+      let(:nickname1) { "Awesome #{friend1.name}" }
+      let(:nickname2) { "Long #{friend2.name} Silver" }
+      let(:description) { "Lunch with #{nickname1} and #{nickname2}." }
+      it "matches friends" do
+        friend1.add_nickname(nickname1)
+        friend2.add_nickname(nickname2)
+        subject
+        activity.description.
+          must_equal "Lunch with **#{friend1.name}** and **#{friend2.name}**."
+      end
+    end
+
     describe "when names are not entered case-sensitively" do
       let(:description) { "Lunch with elizabeth cady stanton." }
       it "matches friends" do


### PR DESCRIPTION
This change fixes an edge case bug in how nicknames could be
matched. If a nickname (like "Amazing Grace") contains a
friend's first name (like "Grace"), previously the first name
would be matched instead of the nickname (like
"Amazing Grace Hopper"). This change reverses that precedence,
so it would match the entire nickname first (like
"Grace Hopper").

This change also updates the README for the recently added
`edit` command.

Resolves #111.