### PR TITLE
Match friends with first name and last name initial

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,15 @@ $ friends add activity "Invented debugging with The Admiral."
 Activity added: "2016-01-06: Invented debugging with Grace Hopper."
 ```
 
+You can also use the first initial of a last name instead of the whole thing.
+`friends` will figure out what to do with those pesky periods (if you include
+them) based on whether you're in the middle of a sentence or not:
+
+```bash
+$ friends add activity "Got lunch with Earnest H and Earnest S. in the park. Man, I like Earnest H. but really love Earnest S."
+Activity added: "2016-05-01: Got lunch with Earnest Hemingway and Earnest Shackleton in the park. Man, I like Earnest Hemingway but really love Earnest Shackleton."
+```
+
 And locations will be matched as well:
 
 ```bash

--- a/lib/friends/friend.rb
+++ b/lib/friends/friend.rb
@@ -104,7 +104,25 @@ module Friends
 
       # We check nicknames before first names because nicknames may contain
       # first names, as in "Amazing Grace" being a nickname for Grace Hopper.
-      [chunks, *@nicknames.map { |n| [n] }, [chunks.first]].map do |words|
+      [
+        chunks,
+        *@nicknames.map { |n| [n] },
+
+        # Match a first name followed by a last name initial, period, and then
+        # (via lookahead) spacing followed by a lowercase letter. This matches
+        # the "Jake E." part of something like "Jake E. and I went skiing." This
+        # allows us to correctly count the period as part of the name when it's
+        # in the middle of a sentence.
+        [chunks.first, "#{chunks.last[0]}\.(?=#{splitter}(?-i)[a-z])"],
+
+        # If the above doesn't match, we check for just the first name and then
+        # a last name initial. This matches the "Jake E" part of something like
+        # "I went skiing with Jake E." This allows us to correctly exclude the
+        # period from the name when it's at the end of a sentence.
+        [chunks.first, chunks.last[0]],
+
+        [chunks.first]
+      ].map do |words|
         Friends::RegexBuilder.regex(words.join(splitter))
       end
     end

--- a/lib/friends/regex_builder.rb
+++ b/lib/friends/regex_builder.rb
@@ -21,17 +21,22 @@ module Friends
     NO_LEADING_ALPHABETICALS = "(?<![A-z])".freeze
     NO_TRAILING_ALPHABETICALS = "(?![A-z])".freeze
 
+    # We ignore case within the regex as opposed to globally to allow consumers
+    # of this API the ability to pass in strings that turn off this modifier
+    # with the "(?-i)" string.
+    IGNORE_CASE = "(?i)".freeze
+
     def self.regex(str)
       Regexp.new(
         NO_LEADING_BACKSLASH +
         NO_LEADING_ASTERISKS +
         NO_LEADING_UNDERSCORES +
         NO_LEADING_ALPHABETICALS +
+        IGNORE_CASE +
         str +
         NO_TRAILING_ALPHABETICALS +
         NO_TRAILING_UNDERSCORES +
-        NO_TRAILING_ASTERISKS,
-        Regexp::IGNORECASE
+        NO_TRAILING_ASTERISKS
       )
     end
   end

--- a/test/activity_spec.rb
+++ b/test/activity_spec.rb
@@ -197,6 +197,54 @@ describe Friends::Activity do
       end
     end
 
+    describe 'when description ends with "<first name> <last name initial>"' do
+      let(:description) { "Lunch with John C" }
+      it "matches the friend" do
+        subject
+        activity.description.
+          must_equal "Lunch with **#{friend2.name}**"
+      end
+    end
+
+    describe 'when description ends with "<first name> <last name initial>".' do
+      let(:description) { "Lunch with John C." }
+      it "matches the friend and keeps the period" do
+        subject
+        activity.description.
+          must_equal "Lunch with **#{friend2.name}**."
+      end
+    end
+
+    describe "when description has \"<first name> <last name initial>\" in "\
+             "the middle of a sentence" do
+      let(:description) { "Lunch with John C in the park." }
+      it "matches the friend" do
+        subject
+        activity.description.
+          must_equal "Lunch with **#{friend2.name}** in the park."
+      end
+    end
+
+    describe "when description has \"<first name> <last name initial>.\" in "\
+             "the middle of a sentence" do
+      let(:description) { "Lunch with John C. in the park." }
+      it "matches the friend and swallows the period" do
+        subject
+        activity.description.
+          must_equal "Lunch with **#{friend2.name}** in the park."
+      end
+    end
+
+    describe "when description has \"<first name> <last name initial>\". at "\
+             "the end of a sentence" do
+      let(:description) { "Lunch with John C. It was great!" }
+      it "matches the friend and keeps the period" do
+        subject
+        activity.description.
+          must_equal "Lunch with **#{friend2.name}**. It was great!"
+      end
+    end
+
     describe "when names are not entered case-sensitively" do
       let(:description) { "Lunch with elizabeth cady stanton." }
       it "matches friends" do


### PR DESCRIPTION
This commit adds name matching for things like "Earnest H" and
"Earnest H." to match a name like "Earnest Hemingway." If a
period follows the last name initial, `friends` attempts to
guess whether the period should be kept or removed based on
whether it appears to be in the middle or the end of a sentence
(this is determined via capitalization).

Resolves #87.