### PR TITLE
Add `list favorite locations` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Extrovert-approved.
   - [Global flags](#global-flags)
   - [Syncing across multiple machines](#syncing-across-multiple-machines)
   - [Command reference](#command-reference)
-    - [`add`](#add)
+    - `add`
       - [`add activity`](#add-activity)
       - [`add friend`](#add-friend)
       - [`add location`](#add-location)
@@ -22,13 +22,15 @@ Extrovert-approved.
     - [`clean`](#clean)
     - [`graph`](#graph)
     - [`help`](#help)
-    - [`list`](#list)
+    - `list`
       - [`list activities`](#list-activities)
-      - [`list favorites`](#list-favorites)
+      - `list favorite`
+        - [`list favorite friends`](#list-favorite-friends)
+        - [`list favorite locations`](#list-favorite-locations)
       - [`list friends`](#list-friends)
       - [`list locations`](#list-locations)
     - [`remove nickname`](#remove-nickname)
-    - [`rename`](#rename)
+    - `rename`
       - [`rename friend`](#rename-friend)
       - [`rename location`](#rename-location)
     - [`set location`](#set)
@@ -177,9 +179,7 @@ alias friends="friends --filename '~/Dropbox/friends.md'"
 
 *Note that the command-line output is colored, which this README cannot show.
 
-#### `add`
-
-##### `add activity`
+#### `add activity`
 
 ```bash
 $ friends add activity "Got lunch with Grace and George."
@@ -240,21 +240,21 @@ $ friends add activity "2015-11-01: Grace and I went to \Marie's Diner. \George 
 Activity added: "2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute."
 ```
 
-##### `add friend`
+#### `add friend`
 
 ```bash
 $ friends add friend "Grace Hopper"
 Friend added: "Grace Hopper"
 ```
 
-##### `add location`
+#### `add location`
 
 ```
 $ friends add location Atlantis
 Location added: "Atlantis"
 ```
 
-##### `add nickname`
+#### `add nickname`
 
 ```bash
 $ friends add nickname "Grace Hopper" "The Admiral"
@@ -344,9 +344,7 @@ $ friends help list
 $ friends help list activities
 ```
 
-#### `list`
-
-##### `list activities`
+#### `list activities`
 
 Lists recent activities:
 
@@ -380,12 +378,12 @@ $ friends list activities --in "New York"
 2014-12-31: Celebrated the new year with Marie Curie in New York City.
 ```
 
-##### `list favorites`
+#### `list favorite friends`
 
 Lists your "favorite" friends (by total number of activities):
 
 ```bash
-$ friends list favorites
+$ friends list favorite friends
 Your favorite friends:
 1. George Washington Carver (2 activities)
 2. Grace Hopper             (1)
@@ -395,13 +393,34 @@ Your favorite friends:
 You can specify a number of favorites to show:
 
 ```bash
-$ friends list favorites --limit 2
+$ friends list favorite friends --limit 2
 Your favorite friends:
 1. George Washington Carver (2 activities)
 2. Grace Hopper             (1)
 ```
 
-##### `list friends`
+#### `list favorite locations`
+
+Lists your "favorite" locations (by total number of activities):
+
+```bash
+$ friends list favorite locations
+Your favorite locations:
+1. Atlantis (2 activities)
+2. Paris    (1)
+3. London   (1)
+```
+
+You can specify a number of favorites to show:
+
+```bash
+$ friends list favorite locations --limit 2
+Your favorite locations:
+1. Atlantis (2 activities)
+2. Paris    (1)
+```
+
+#### `list friends`
 
 Lists all of your friends:
 
@@ -419,7 +438,7 @@ $ friends list friends --in Paris
 Marie Curie
 ```
 
-##### `list locations`
+#### `list locations`
 
 Lists all of the locations you've added:
 
@@ -439,16 +458,14 @@ $ friends remove nickname "Grace Hopper" "The Admiral"
 Nickname removed: "Grace Hopper (a.k.a. Amazing Grace)"
 ```
 
-#### `rename`
-
-##### `rename friend`
+#### `rename friend`
 
 ```bash
 $ friends rename friend "Grace Hopper" "Grace Brewster Murray Hopper"
 Name changed: "Grace Brewster Murray Hopper (a.k.a. Amazing Grace)"
 ```
 
-##### `rename location`
+#### `rename location`
 
 ```bash
 $ friends rename location Paris "Paris, France"

--- a/bin/friends
+++ b/bin/friends
@@ -79,25 +79,52 @@ command :list do |list|
     end
   end
 
-  list.desc "List favorite friends"
-  list.command :favorites do |list_favorites|
-    list_favorites.flag [:limit],
-                        arg_name: "NUMBER",
-                        default_value: 10,
-                        desc: "The number of friends to return"
+  list.desc "List favorite friends and locations"
+  list.command :favorite do |list_favorite|
+    list_favorite.desc "List favorite friends"
+    list_favorite.command :friends do |list_favorite_friends|
+      list_favorite_friends.flag [:limit],
+                                 arg_name: "NUMBER",
+                                 default_value: 10,
+                                 desc: "The number of friends to return"
 
-    list_favorites.action do |_, options|
-      limit = options[:limit].to_i
-      favorites = @introvert.list_favorites(limit: limit)
+      list_favorite_friends.action do |_, options|
+        limit = options[:limit].to_i
+        favorites = @introvert.list_favorite_friends(limit: limit)
 
-      if limit == 1
-        puts "Your best friend is #{favorites.first}"
-      else
-        puts "Your favorite friends:"
+        if limit == 1
+          puts "Your best friend is #{favorites.first}"
+        else
+          puts "Your favorite friends:"
 
-        num_str_size = favorites.size.to_s.size + 1
-        favorites.each.with_index(1) do |name, rank|
-          puts "#{"#{rank}.".ljust(num_str_size)} #{name}"
+          num_str_size = favorites.size.to_s.size + 1
+          favorites.each.with_index(1) do |name, rank|
+            puts "#{"#{rank}.".ljust(num_str_size)} #{name}"
+          end
+        end
+      end
+    end
+
+    list_favorite.desc "List favorite locations"
+    list_favorite.command :locations do |list_favorite_locations|
+      list_favorite_locations.flag [:limit],
+                                   arg_name: "NUMBER",
+                                   default_value: 10,
+                                   desc: "The number of locations to return"
+
+      list_favorite_locations.action do |_, options|
+        limit = options[:limit].to_i
+        favorites = @introvert.list_favorite_locations(limit: limit)
+
+        if limit == 1
+          puts "Your favorite location is #{favorites.first}"
+        else
+          puts "Your favorite locations:"
+
+          num_str_size = favorites.size.to_s.size + 1
+          favorites.each.with_index(1) do |name, rank|
+            puts "#{"#{rank}.".ljust(num_str_size)} #{name}"
+          end
         end
       end
     end

--- a/lib/friends/activity.rb
+++ b/lib/friends/activity.rb
@@ -127,6 +127,13 @@ module Friends
     end
     memoize :friend_names
 
+    # Find the names of all locations in this description.
+    # @return [Array] list of all location names in the description
+    def location_names
+      @description.scan(/(?<=_)\w[^_]*(?=_)/).uniq
+    end
+    memoize :location_names
+
     private
 
     # Modify the description to turn inputted location names (e.g. "Atlantis")
@@ -184,7 +191,7 @@ module Friends
       end
 
       # Now, we compute the likelihood of each friend in the possible-match set.
-      introvert.set_n_activities!
+      introvert.set_friend_n_activities!
       introvert.set_likelihood_score!(
         matches: matched_friends,
         possible_matches: possible_matched_friends

--- a/lib/friends/location.rb
+++ b/lib/friends/location.rb
@@ -39,6 +39,13 @@ module Friends
       Friends::RegexBuilder.regex(@name)
     end
 
+    # The number of activities this location is in. This is for internal use
+    # only and is set by the Introvert as needed.
+    attr_writer :n_activities
+    def n_activities
+      @n_activities || 0
+    end
+
     private
 
     # Default sorting for an array of locations is alphabetical.

--- a/test/introvert_spec.rb
+++ b/test/introvert_spec.rb
@@ -562,23 +562,8 @@ describe Friends::Introvert do
     end
   end
 
-  describe "#list_favorites" do
-    subject { introvert.list_favorites(limit: limit) }
-
-    describe "when limit is nil" do
-      let(:limit) { nil }
-
-      it "returns all friends in order of favoritism with activity counts" do
-        stub_friends(friends) do
-          stub_activities(activities) do
-            subject.must_equal [
-              "Betsy Ross               (2 activities)",
-              "George Washington Carver (1)"
-            ]
-          end
-        end
-      end
-    end
+  describe "#list_favorite_friends" do
+    subject { introvert.list_favorite_friends(limit: limit) }
 
     describe "when there are more friends than favorites requested" do
       let(:limit) { 1 }
@@ -587,6 +572,24 @@ describe Friends::Introvert do
         stub_friends(friends) do
           stub_activities(activities) do
             subject.must_equal ["Betsy Ross (2 activities)"]
+          end
+        end
+      end
+    end
+  end
+
+  describe "#list_favorite_locations" do
+    subject { introvert.list_favorite_locations(limit: limit) }
+
+    describe "when there are more locations than favorites requested" do
+      let(:limit) { 1 }
+
+      it "returns the number of favorites requested" do
+        stub_locations(locations) do
+          stub_activities(
+            [Friends::Activity.new(str: "Swimming in _Atlantis_.")]
+          ) do
+            subject.must_equal ["Atlantis (1 activity)"]
           end
         end
       end


### PR DESCRIPTION
This commit splits the previous `list favorites` command into
two commands: `list favorite friends` and `list favorite locations`.

This commit also adjusts the README.md headings slightly so each
command has a quadruple-hash heading instead of depending on the
command's nested level.

Resolves #108.