### PR TITLE
Fix favorite commands (undefined variable "limit")

### DIFF
--- a/bin/friends
+++ b/bin/friends
@@ -179,7 +179,7 @@ command :list do |list|
       list_favorite_friends.action do |_, options|
         favorites = @introvert.list_favorite_friends(limit: options[:limit])
 
-        if limit == 1
+        if options[:limit] == 1
           puts "Your best friend is #{favorites.first}"
         else
           puts "Your favorite friends:"
@@ -203,7 +203,7 @@ command :list do |list|
       list_favorite_locations.action do |_, options|
         favorites = @introvert.list_favorite_locations(limit: options[:limit])
 
-        if limit == 1
+        if options[:limit] == 1
           puts "Your favorite location is #{favorites.first}"
         else
           puts "Your favorite locations:"


### PR DESCRIPTION
Fixes this little bug:

```
$ friends list favorite friends
Error: undefined local variable or method `limit' for main:Object
```

`bin/friends` is now over 400 lines with no tests. I wonder if it's time to add some full integration tests and then try and break it up into a few logical chunks...

