### PR TITLE
Add --since and --until flags to `graph` and `list activities`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ lots of help), and give feedback!**
     - `rename`
       - [`rename friend`](#rename-friend)
       - [`rename location`](#rename-location)
-    - [`set location`](#set)
+    - [`set location`](#set-location)
     - [`stats`](#stats)
     - [`suggest`](#suggest)
     - [`update`](#update)
@@ -363,10 +363,27 @@ Jan 2015 |
 Feb 2015 |█
 ```
 
+Or graph only activities on or after a certain date:
+
+```bash
+$ friends graph --since 'January 1st 2015'
+Jan 2015 |███████
+Feb 2015 |█████
+```
+
+Or graph only activities before or on a certain date:
+
+```bash
+$ friends graph --until 'January 1st 2015'
+Nov 2014 |███
+Dec 2014 |██
+Jan 2015 |███████
+```
+
 And you can use multiple of these flags together:
 
 ```bash
-$ friends graph --in Paris --tagged food --with George
+$ friends graph --in Paris --tagged food --with George --after 'September 2014'
 Nov 2014 |█
 ```
 
@@ -438,6 +455,20 @@ Or by tag:
 ```bash
 $ friends list activities --tagged food
 2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
+```
+
+Or by date:
+
+```bash
+$ friends graph --since 'December 31st 2014'
+2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
+2014-12-31: Celebrated the new year with Marie Curie in New York City. @partying
+```
+
+```bash
+$ friends graph --until 'December 31st 2014'
+2014-12-31: Celebrated the new year with Marie Curie in New York City. @partying
+2014-11-15: Talked to George Washington Carver on the phone for an hour.
 ```
 
 And you can mix and match these options to your heart's content:

--- a/bin/friends
+++ b/bin/friends
@@ -39,6 +39,12 @@ end
 class Stripped; end
 accept(Stripped, &:strip)
 
+class InputDate; end
+accept(InputDate) do |value|
+  time = Chronic.parse(value)
+  time && time.to_date
+end
+
 switch [:quiet],
        negatable: false,
        desc: "Quiet output messages"

--- a/lib/friends/commands/graph.rb
+++ b/lib/friends/commands/graph.rb
@@ -17,6 +17,16 @@ command :graph do |graph|
              desc: "Graph activities with the given tag",
              type: Tag
 
+  graph.flag [:since],
+             arg_name: "DATE",
+             desc: "Graph activities on or after the given date",
+             type: InputDate
+
+  graph.flag [:until],
+             arg_name: "DATE",
+             desc: "Graph activities before or on the given date",
+             type: InputDate
+
   graph.action do |_, options|
     # This math is taken from Minitest's Pride plugin (the PrideLOL class).
     PI_3 = Math::PI / 3
@@ -33,7 +43,9 @@ command :graph do |graph|
     data = @introvert.graph(
       with: options[:with],
       location_name: options[:in],
-      tagged: options[:tagged]
+      tagged: options[:tagged],
+      since_date: options[:since],
+      until_date: options[:until]
     )
 
     data.each do |month, count|

--- a/lib/friends/commands/list.rb
+++ b/lib/friends/commands/list.rb
@@ -50,12 +50,24 @@ command :list do |list|
                          desc: "List only activities with the given tag",
                          type: Tag
 
+    list_activities.flag [:since],
+                         arg_name: "DATE",
+                         desc: "List only activities on or after the given date",
+                         type: InputDate
+
+    list_activities.flag [:until],
+                         arg_name: "DATE",
+                         desc: "List only activities before or on the given date",
+                         type: InputDate
+
     list_activities.action do |_, options|
       puts @introvert.list_activities(
         limit: options[:limit],
         with: options[:with],
         location_name: options[:in],
-        tagged: options[:tagged]
+        tagged: options[:tagged],
+        since_date: options[:since],
+        until_date: options[:until]
       )
     end
   end

--- a/lib/friends/graph.rb
+++ b/lib/friends/graph.rb
@@ -5,13 +5,13 @@ module Friends
   class Graph
     DATE_FORMAT = "%b %Y"
 
-    # @param start_date [Date] the first month of the graph
-    # @param end_date [Date] the last month of the graph
     # @param activities [Array<Friends::Activity>] a list of activities to graph
-    def initialize(start_date:, end_date:, activities:)
-      self.start_date = start_date
-      self.end_date = end_date
-      self.activities = activities
+    def initialize(activities:)
+      @activities = activities
+      unless @activities.empty?
+        @start_date = @activities.last.date
+        @end_date = @activities.first.date
+      end
     end
 
     # Render the graph as a hash in the format:
@@ -45,7 +45,7 @@ module Friends
     #
     # @return [Hash{String => Integer}]
     def empty_graph
-      Hash[(start_date..end_date).map do |date|
+      Hash[(start_date && end_date ? (start_date..end_date) : []).map do |date|
         [format_date(date), 0]
       end]
     end

--- a/test/commands/graph_spec.rb
+++ b/test/commands/graph_spec.rb
@@ -54,19 +54,7 @@ Nov 2015 |█
         let(:location_name) { "paris" }
         it "matches location case-insensitively" do
           stdout_only <<-OUTPUT
-Nov 2014 |
 Dec 2014 |█
-Jan 2015 |
-Feb 2015 |
-Mar 2015 |
-Apr 2015 |
-May 2015 |
-Jun 2015 |
-Jul 2015 |
-Aug 2015 |
-Sep 2015 |
-Oct 2015 |
-Nov 2015 |
           OUTPUT
         end
       end
@@ -99,16 +87,6 @@ Nov 2015 |
 Nov 2014 |█
 Dec 2014 |
 Jan 2015 |█
-Feb 2015 |
-Mar 2015 |
-Apr 2015 |
-May 2015 |
-Jun 2015 |
-Jul 2015 |
-Aug 2015 |
-Sep 2015 |
-Oct 2015 |
-Nov 2015 |
           OUTPUT
         end
       end
@@ -119,8 +97,6 @@ Nov 2015 |
 
       it "matches tag case-sensitively" do
         stdout_only <<-OUTPUT
-Nov 2014 |
-Dec 2014 |
 Jan 2015 |█
 Feb 2015 |
 Mar 2015 |
@@ -132,6 +108,38 @@ Aug 2015 |
 Sep 2015 |
 Oct 2015 |
 Nov 2015 |█
+        OUTPUT
+      end
+    end
+
+    describe "--since" do
+      subject { run_cmd("graph --since 'January 4th 2015'") }
+
+      it "graphs activities on and after the specified date" do
+        stdout_only <<-OUTPUT
+Jan 2015 |█
+Feb 2015 |
+Mar 2015 |
+Apr 2015 |
+May 2015 |
+Jun 2015 |
+Jul 2015 |
+Aug 2015 |
+Sep 2015 |
+Oct 2015 |
+Nov 2015 |█
+        OUTPUT
+      end
+    end
+
+    describe "--after" do
+      subject { run_cmd("graph --until 'January 4th 2015'") }
+
+      it "graphs activities before and on the specified date" do
+        stdout_only <<-OUTPUT
+Nov 2014 |█
+Dec 2014 |█
+Jan 2015 |█
         OUTPUT
       end
     end

--- a/test/commands/list/activities_spec.rb
+++ b/test/commands/list/activities_spec.rb
@@ -109,5 +109,28 @@ clean_describe "list activities" do
         OUTPUT
       end
     end
+
+    describe "--since" do
+      subject { run_cmd("list activities --since 'January 4th 2015'") }
+
+      it "lists activities on and after the specified date" do
+        stdout_only <<-OUTPUT
+2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
+2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute. @food
+        OUTPUT
+      end
+    end
+
+    describe "--after" do
+      subject { run_cmd("list activities --until 'January 4th 2015'") }
+
+      it "lists activities before and on the specified date" do
+        stdout_only <<-OUTPUT
+2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
+2014-11-15: Talked to George Washington Carver on the phone for an hour.
+2014-12-31: Celebrated the new year in Paris with Marie Curie. @partying
+        OUTPUT
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit adds optional `--since` and `--until` flags that
can be used to filter down the activities displayed in the
`graph` and `list activities` commands.

It also changes the behavior of `graph` so that leading and
trailing months with no activities are not graphed.

Lastly, this commit fixes a typo in the README that was causing
a table-of-contents link to not work.

Closes #153.

Hi there! Thanks so much for submitting a pull request!

Let's just make sure together that all of these boxes are checked before we
merge this change:

- [x] The code in these changes works correctly.
- [x] Code has tests as appropriate.
- [x] Code has been reviewed by @JacobEvelyn.
- [x] All tests pass on TravisCI.
- [x] Rubocop reports no issues on TravisCI.
- [x] The `README.md` file is updated as appropriate.

Don't worry—this list will get checked off in no time!
