### PR TITLE
Be able to filter output by more than one friend or tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,13 @@ Jan 2015 |█████
 Feb 2015 |███
 ```
 
+Or a certain group of friends:
+
+```bash
+$ friends graph --with George --with Grace
+Jan 2015 |█
+```
+
 Or graph only activities with a certain tag:
 
 ```bash
@@ -351,6 +358,13 @@ Nov 2014 |█
 Dec 2014 |
 Jan 2015 |
 Feb 2015 |███
+```
+
+Or with multiple tags:
+
+```bash
+$ friends graph --tagged @fun --tagged @work
+Jul 2017 |█
 ```
 
 Or graph only activities in a certain location:
@@ -443,6 +457,13 @@ $ friends list activities --with George
 2014-11-15: Talked to George Washington Carver on the phone for an hour.
 ```
 
+Or only filter activities done with a group of friends:
+
+```bash
+$ friends list activities --with George --with Grace
+2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
+```
+
 Or filter your activities by location:
 
 ```bash
@@ -457,16 +478,23 @@ $ friends list activities --tagged food
 2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
 ```
 
+Or use more than one tag:
+
+```bash
+$ friends list activities --tagged @fun --tagged @work
+2017-07-04: Summer picnic with @work colleagues. @fun
+```
+
 Or by date:
 
 ```bash
-$ friends graph --since 'December 31st 2014'
+$ friends list activities --since 'December 31st 2014'
 2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
 2014-12-31: Celebrated the new year with Marie Curie in New York City. @partying
 ```
 
 ```bash
-$ friends graph --until 'December 31st 2014'
+$ friends list activities --until 'December 31st 2014'
 2014-12-31: Celebrated the new year with Marie Curie in New York City. @partying
 2014-11-15: Talked to George Washington Carver on the phone for an hour.
 ```
@@ -474,7 +502,7 @@ $ friends graph --until 'December 31st 2014'
 And you can mix and match these options to your heart's content:
 
 ```bash
-$ friends list activities --tagged food --with Grace
+$ friends list activities --tagged food --with Grace --with George
 2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
 ```
 
@@ -553,6 +581,13 @@ And you can also filter your friends by tag:
 $ friends list friends --tagged science
 Grace Hopper
 Marie Curie
+```
+
+You can even use more than one tag to further narrow down the list:
+
+```bash
+$ friends list friends --tagged science --tagged navy
+Grace Hopper
 ```
 
 #### `list tags`

--- a/lib/friends/commands/graph.rb
+++ b/lib/friends/commands/graph.rb
@@ -5,7 +5,8 @@ command :graph do |graph|
   graph.flag [:with],
              arg_name: "NAME",
              desc: "Graph activities with the given friend",
-             type: Stripped
+             type: Stripped,
+             multiple: true
 
   graph.flag [:in],
              arg_name: "LOCATION",
@@ -15,7 +16,8 @@ command :graph do |graph|
   graph.flag [:tagged],
              arg_name: "@TAG",
              desc: "Graph activities with the given tag",
-             type: Tag
+             type: Tag,
+             multiple: true
 
   graph.flag [:since],
              arg_name: "DATE",

--- a/lib/friends/commands/list.rb
+++ b/lib/friends/commands/list.rb
@@ -12,7 +12,8 @@ command :list do |list|
     list_friends.flag [:tagged],
                       arg_name: "@TAG",
                       desc: "List only friends with the given tag",
-                      type: Tag
+                      type: Tag,
+                      multiple: true
 
     list_friends.switch [:verbose],
                         negatable: false,
@@ -38,7 +39,8 @@ command :list do |list|
     list_activities.flag [:with],
                          arg_name: "NAME",
                          desc: "List only activities with the given friend",
-                         type: Stripped
+                         type: Stripped,
+                         multiple: true
 
     list_activities.flag [:in],
                          arg_name: "LOCATION",
@@ -48,7 +50,8 @@ command :list do |list|
     list_activities.flag [:tagged],
                          arg_name: "@TAG",
                          desc: "List only activities with the given tag",
-                         type: Tag
+                         type: Tag,
+                         multiple: true
 
     list_activities.flag [:since],
                          arg_name: "DATE",

--- a/test/commands/graph_spec.rb
+++ b/test/commands/graph_spec.rb
@@ -90,6 +90,16 @@ Jan 2015 |█
           OUTPUT
         end
       end
+
+      describe "when more than one friend name is passed" do
+        subject { run_cmd("graph --with #{friend_name1} --with #{friend_name2}") }
+        let(:friend_name1) { "george" }
+        let(:friend_name2) { "grace" }
+
+        it "matches all friends case-insensitively" do
+          stdout_only "Jan 2015 |█"
+        end
+      end
     end
 
     describe "--tagged" do
@@ -109,6 +119,30 @@ Sep 2015 |
 Oct 2015 |
 Nov 2015 |█
         OUTPUT
+      end
+
+      describe "when more than one tag is passed" do
+        subject { run_cmd("graph --tagged #{tag1} --tagged #{tag2}") }
+        let(:tag1) { "food" }
+        let(:tag2) { "partying" }
+        let(:content) do
+          <<-FILE
+### Activities:
+- 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
+- 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying @food
+
+### Friends:
+- George Washington Carver
+- Marie Curie [Atlantis] @science
+- Grace Hopper (a.k.a. The Admiral a.k.a. Amazing Grace) [Paris] @navy @science
+FILE
+        end
+
+        it "matches all tags case-sensitively" do
+          stdout_only "Dec 2014 |█"
+        end
       end
     end
 

--- a/test/commands/list/activities_spec.rb
+++ b/test/commands/list/activities_spec.rb
@@ -97,6 +97,16 @@ clean_describe "list activities" do
           stdout_only "2014-12-31: Celebrated the new year in Paris with Marie Curie. @partying"
         end
       end
+
+      describe "when more than one friend name is passed" do
+        subject { run_cmd("list activities --with #{friend_name1} --with #{friend_name2}") }
+        let(:friend_name1) { "george" }
+        let(:friend_name2) { "grace" }
+
+        it "matches all friends case-insensitively" do
+          stdout_only "2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food"
+        end
+      end
     end
 
     describe "--tagged" do
@@ -107,6 +117,32 @@ clean_describe "list activities" do
 2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
 2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute. @food
         OUTPUT
+      end
+
+      describe "when more than one tag is passed" do
+        subject { run_cmd("list activities --tagged #{tag1} --tagged #{tag2}") }
+        let(:tag1) { "food" }
+        let(:tag2) { "partying" }
+        let(:content) do
+          <<-FILE
+### Activities:
+- 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
+- 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying @food
+
+### Friends:
+- George Washington Carver
+- Marie Curie [Atlantis] @science
+- Grace Hopper (a.k.a. The Admiral a.k.a. Amazing Grace) [Paris] @navy @science
+FILE
+        end
+
+        it "matches all tags case-sensitively" do
+          stdout_only(
+            "2014-12-31: Celebrated the new year in Paris with Marie Curie. @partying @food"
+          )
+        end
       end
     end
 

--- a/test/commands/list/friends_spec.rb
+++ b/test/commands/list/friends_spec.rb
@@ -71,6 +71,31 @@ Marie Curie
 Grace Hopper
         OUTPUT
       end
+
+      describe "when more than one tag is passed" do
+        subject { run_cmd("list friends --tagged #{tag1} --tagged #{tag2}") }
+        let(:tag1) { "science" }
+        let(:tag2) { "navy" }
+        let(:content) do
+          <<-FILE
+### Activities:
+
+### Friends:
+- George Washington Carver
+- Grace Hopper (a.k.a. The Admiral a.k.a. Amazing Grace) [Paris] @navy @science
+- Marie Curie [Atlantis] @science
+- Neil Armstrong @navy @science
+- John F. Kennedy @navy
+FILE
+        end
+
+        it "matches all tags case-sensitively" do
+          stdout_only <<-OUTPUT
+Grace Hopper
+Neil Armstrong
+        OUTPUT
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This commit allows you to use multiple --with or --tagged
flags in the following commands:

- `list friends`
- `list activities`
- `graph`

Closes #88.

Hi there! Thanks so much for submitting a pull request!

Let's just make sure together that all of these boxes are checked before we
merge this change:

- [x] The code in these changes works correctly.
- [x] Code has tests as appropriate.
- [x] Code has been reviewed by @JacobEvelyn.
- [x] All tests pass on Travis CI.
- [x] Rubocop reports no issues on Travis CI.
- [x] The `README.md` file is updated as appropriate.

Don't worry—this list will get checked off in no time!
