### PR TITLE
Remove warnings when running tests

### DIFF
--- a/lib/friends.rb
+++ b/lib/friends.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "friends/introvert"
 require "friends/version"
 
 module Friends

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "date"
+
 require "./test/helper"
 
 def date_parsing_specs(test_stdout: true)

--- a/test/commands/clean_spec.rb
+++ b/test/commands/clean_spec.rb
@@ -4,12 +4,15 @@ require "./test/helper"
 
 clean_describe "clean" do
   subject { run_cmd("clean") }
+  let(:content) { nil }
 
   it "outputs a message" do
     stdout_only "File cleaned: \"#{filename}\""
   end
 
   describe "when file does not exist" do
+    let(:content) { nil }
+
     it "does not create the file" do
       File.exist?(filename).must_equal false
     end

--- a/test/commands/graph_spec.rb
+++ b/test/commands/graph_spec.rb
@@ -6,6 +6,8 @@ clean_describe "graph" do
   subject { run_cmd("graph") }
 
   describe "when file does not exist" do
+    let(:content) { nil }
+
     it "prints no output" do
       stdout_only ""
     end

--- a/test/commands/help_spec.rb
+++ b/test/commands/help_spec.rb
@@ -4,6 +4,7 @@ require "./test/helper"
 
 clean_describe "help" do
   subject { run_cmd("help") }
+  let(:content) { nil }
 
   describe "with no subcommand passed" do
     it "prints overall help message" do

--- a/test/commands/list/activities_spec.rb
+++ b/test/commands/list/activities_spec.rb
@@ -6,6 +6,8 @@ clean_describe "list activities" do
   subject { run_cmd("list activities") }
 
   describe "when file does not exist" do
+    let(:content) { nil }
+
     it "does not list anything" do
       stdout_only ""
     end

--- a/test/commands/list/favorite/friends_spec.rb
+++ b/test/commands/list/favorite/friends_spec.rb
@@ -6,6 +6,8 @@ clean_describe "list favorite friends" do
   subject { run_cmd("list favorite friends") }
 
   describe "when file does not exist" do
+    let(:content) { nil }
+
     it "prints a no-data message" do
       stdout_only "Your favorite friends:"
     end

--- a/test/commands/list/favorite/locations_spec.rb
+++ b/test/commands/list/favorite/locations_spec.rb
@@ -6,6 +6,8 @@ clean_describe "list favorite locations" do
   subject { run_cmd("list favorite locations") }
 
   describe "when file does not exist" do
+    let(:content) { nil }
+
     it "prints a no-data message" do
       stdout_only "Your favorite locations:"
     end

--- a/test/commands/list/friends_spec.rb
+++ b/test/commands/list/friends_spec.rb
@@ -6,6 +6,8 @@ clean_describe "list friends" do
   subject { run_cmd("list friends") }
 
   describe "when file does not exist" do
+    let(:content) { nil }
+
     it "does not list anything" do
       stdout_only ""
     end

--- a/test/commands/list/locations_spec.rb
+++ b/test/commands/list/locations_spec.rb
@@ -6,6 +6,8 @@ clean_describe "list locations" do
   subject { run_cmd("list locations") }
 
   describe "when file does not exist" do
+    let(:content) { nil }
+
     it "does not list anything" do
       stdout_only ""
     end

--- a/test/commands/list/tags_spec.rb
+++ b/test/commands/list/tags_spec.rb
@@ -6,6 +6,8 @@ clean_describe "list tags" do
   subject { run_cmd("list tags") }
 
   describe "when file does not exist" do
+    let(:content) { nil }
+
     it "does not list anything" do
       stdout_only ""
     end

--- a/test/commands/stats_spec.rb
+++ b/test/commands/stats_spec.rb
@@ -6,6 +6,8 @@ clean_describe "stats" do
   subject { run_cmd("stats") }
 
   describe "when file does not exist" do
+    let(:content) { nil }
+
     it "returns the stats" do
       stdout_only <<-FILE
 Total activities: 0

--- a/test/commands/suggest_spec.rb
+++ b/test/commands/suggest_spec.rb
@@ -6,6 +6,8 @@ clean_describe "suggest" do
   subject { run_cmd("suggest") }
 
   describe "when file does not exist" do
+    let(:content) { nil }
+
     it "prints a no-data message" do
       stdout_only <<-FILE
 Distant friend: None found

--- a/test/commands/update_spec.rb
+++ b/test/commands/update_spec.rb
@@ -4,6 +4,7 @@ require "./test/helper"
 
 clean_describe "update" do
   subject { run_cmd("update") }
+  let(:content) { nil }
 
   it "prints a status message" do
     subject[:stderr].must_equal ""

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -123,7 +123,6 @@ end
 def clean_describe(desc, *additional_desc, &block)
   describe desc, *additional_desc do
     let(:filename) { "test/tmp/friends#{SecureRandom.uuid}.md" }
-    let(:content) { nil }
 
     before { File.write(filename, content) unless content.nil? }
     after { File.delete(filename) if File.exist?(filename) }


### PR DESCRIPTION
This commit removes warnings that were appearing as a result of
re-defining the `let(:content)` across both `helper.rb` and test
files, and warnings from removing a circular `require` chain.

Hi there! Thanks so much for submitting a pull request!

Let's just make sure together that all of these boxes are checked before we
merge this change:

- [x] The code in these changes works correctly.
- [x] Code has tests as appropriate.
- [x] Code has been reviewed by @JacobEvelyn.
- [x] All tests pass on Travis CI.
- [x] Rubocop reports no issues on Travis CI.
- [x] The `README.md` file is updated as appropriate.

Don't worry—this list will get checked off in no time!
