### PR TITLE
Fix bug with date parsing month and day

### DIFF
--- a/lib/friends/activity.rb
+++ b/lib/friends/activity.rb
@@ -34,9 +34,15 @@ module Friends
       # Partition lets us parse "Today" and "Today: I awoke." identically.
       date_s, _, description = str.partition(DATE_PARTITION)
 
-      # rubocop:disable Lint/AssignmentInCondition
-      if time = (date_s =~ /^\d{4}-\d{2}-\d{2}$/ ? Time : Chronic).parse(date_s)
-        # rubocop:enable Lint/AssignmentInCondition
+      time = if date_s =~ /^\d{4}-\d{2}-\d{2}$/
+               Time.parse(date_s)
+             else
+               # If the user inputed a non YYYY-MM-DD format, asssume
+               # it is in the past
+               Chronic.parse(date_s, { context: :past })
+             end
+
+      if time
         @date = time.to_date
         @description = description
       else

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -29,11 +29,30 @@ def date_parsing_specs(test_stdout: true)
       it { stdout_only "Activity added: \"2017-03-02: #{description}\"" } if test_stdout
     end
 
-    describe "when date is natural language" do
+    describe "when date is natural language and in full" do
       let(:date) { "February 23rd, 2017" }
 
       it { line_added "- 2017-02-23: #{description}" }
       it { stdout_only "Activity added: \"2017-02-23: #{description}\"" } if test_stdout
+    end
+
+    describe "when date is natural language and only month and day" do
+      mocked_time = Time.new(2017, 8, 1) # First of August
+      let(:date) { "February 23" }
+
+      Time.stub :now, mocked_time do
+        # Infers it means the last february not the next
+        it { line_added "- 2017-02-23: #{description}" }
+        it { stdout_only "Activity added: \"2017-02-23: #{description}\"" } if test_stdout
+      end
+
+      let(:date) { "23 February" }
+
+      Time.stub :now, mocked_time do
+        # Infers it means the last february not the next
+        it { line_added "- 2017-02-23: #{description}" }
+        it { stdout_only "Activity added: \"2017-02-23: #{description}\"" } if test_stdout
+      end
     end
   end
 end


### PR DESCRIPTION
It was returning a date in the future instead of in the past.
For example, "July 20" would return "2018-07-20" instead of "2017-07-20"
when the current year is 2017.

Doing `friends add activity July 20` would result in
`2018-07-20: `
when it should have been:
`2017-07-20: `

---

Hi there! Thanks so much for submitting a pull request!

Let's just make sure together that all of these boxes are checked before we
merge this change:

- [x] The code in these changes works correctly.
- [ ] Code has tests as appropriate.
- [ ] Code has been reviewed by @JacobEvelyn.
- [x] All tests pass on Travis CI.
- [x] Rubocop reports no issues on Travis CI.
- [x] The `README.md` file is updated as appropriate.

Don't worry—this list will get checked off in no time!
