### PR TITLE
Add ability to add new friends and locations from events

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,9 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Enabled: false
 
+Metrics/BlockNesting:
+  Enabled: false
+
 Metrics/ClassLength:
   Enabled: false
 

--- a/README.md
+++ b/README.md
@@ -314,6 +314,22 @@ $ friends add activity "2018-11-01: Grace and I went to \Marie's Diner. \George 
 Activity added: "2018-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute."
 ```
 
+And if an activity contains friends or locations you haven't yet added, you can simply
+denote them with the signifiers found in the `friends.md` file (`**`s around friends,
+and `_`s around locations), and `friends` will automatically add the friends or locations
+that are missing:
+
+```bash
+$ friends add activity "2018-11-01: I got to meet **Oprah Winfrey** in _Chicago_ today."
+Activity added: "2018-11-01: I got to meet Oprah Winfrey in Chicago today."
+Friend added: "Oprah Winfrey"
+Location added: "Chicago"
+```
+
+This is really handy for when you have an activity involving a friend or location that
+you can't remember if you've already added. Just use the signifiers and
+they'll be added if necessary!
+
 #### `add note`
 
 Notes can be added exactly like activities, either on one line:
@@ -330,7 +346,20 @@ $ friends add note last Monday
 2017-03-07: <type description here>
 ```
 
-And just like with `add activity`, dates, friends, locations, nicknames, and tags will all be intelligently matched.
+And just like with `add activity`, dates, friends, locations, nicknames, and tags will all be
+intelligently matched. In addition, as with `add activity` you can use the `**`/`_` signifiers
+around friend and location names and they'll be added if necessary:
+
+```bash
+$ friends add note "2018-11-01: **Oprah Winfrey** grew up in _Chicago_."
+Activity added: "2018-11-01: Oprah Winfrey grew up in Chicago."
+Friend added: "Oprah Winfrey"
+Location added: "Chicago"
+```
+
+This is really handy for when you have a note involving a friend or location that
+you can't remember if you've already added. Just use the signifiers and
+they'll be added if necessary!
 
 #### `add friend`
 
@@ -372,7 +401,9 @@ File cleaned: "./friends.md"
 ```
 
 This command is useful after manual editing of the file, for re-ordering its
-contents.
+contents and adding any missing friends or locations that are found in
+activities or notes. Note that `friends clean` is automatically called after
+the editor in `friends edit` is closed.
 
 #### `edit`
 
@@ -380,16 +411,42 @@ Allows you to manually edit the file:
 
 ```bash
 $ friends edit
-Opening "./friends.md" in vim
+Opening "./friends.md" with "vim"
 ```
 
-The file is opened with the command specified by the `$EDITOR` environment
+The file is opened with the command specified by the `EDITOR` environment
 variable, falling back to `vim` if it is not set:
 
 ```bash
-$ export EDITOR=atom
+$ export EDITOR='atom --wait'
 $ friends edit
-Opening "./friends.md" in atom
+Opening "./friends.md" with "atom --wait"
+```
+
+Note that when setting your own `EDITOR` value, if you like to use
+an editor like Atom, VS Code, or Sublime Text, you should first make
+sure you have the command-line tool for your editor (`atom`, `code`,
+or `subl`) installed correctly so you can open your editor from the
+command line. Then, when setting `EDITOR`, make sure to use the
+`--wait` flag (as in the example above), which will allow `friends`
+to be able to run the `clean` command (see below).
+
+After the editor has been closed, `friends` will automatically run the
+`clean` command to re-organize the file and add any friends or locations
+you've referenced in activities or notes that have not been added to the
+file. This means that, similar to the `add activity` and `add note`
+commands, you can add lines like:
+
+```markdown
+- 2018-01-01: I just met **Oprah Winfrey** in _Chicago_!
+```
+
+And if that friend or location isn't already present it'll be added:
+
+```bash
+Friend added: "Oprah Winfrey"
+Location added: "Chicago"
+File cleaned: "./friends.md\"
 ```
 
 #### `graph`
@@ -800,12 +857,16 @@ $ friends rename friend "Grace Hopper" "Grace Brewster Murray Hopper"
 Name changed: "Grace Brewster Murray Hopper (a.k.a. Amazing Grace)"
 ```
 
+This will update that friend's name in all notes and activities.
+
 #### `rename location`
 
 ```bash
 $ friends rename location Paris "Paris, France"
 Location renamed: "Paris, France"
 ```
+
+This will update that location's name in all notes and activities.
 
 #### `set location`
 

--- a/bin/friends
+++ b/bin/friends
@@ -72,34 +72,30 @@ switch [:colorless],
 commands_from "friends/commands"
 
 # Before each command, clean up all arguments and create the global Introvert.
-pre do |global_options, cmd, options|
+pre do |global_options, cmd|
   # If the --colorless flag is passed, don't do any fancy painting.
   Paint.mode = 0 if global_options[:colorless]
 
   @debug_mode = global_options[:debug]
 
-  final_options = global_options.merge!(options).select do |key, _|
-    [:filename].include? key
-  end
-
   # If we're updating the friends program we don't need to read the friends file
   # but we don't skip this block entirely because we might still want to enable
-  # debug mode.
-  @introvert = Friends::Introvert.new(final_options) unless cmd.name == :update
+  # debug mode. If we're in a `friends edit` command we wait to initialize the
+  # @introvert until the command block when the system call has exited
+  # successfully.
+  unless [:update, :edit].include? cmd.name
+    @introvert = Friends::Introvert.new(
+      filename: global_options[:filename],
+      quiet: global_options[:quiet]
+    )
+  end
 
   true # Continue executing the command.
 end
 
-post do |global_options|
+post do
   # After each command, clean the file if we have modifications to make.
-  filename = @introvert.clean if @dirty
-
-  # This is a special-case piece of code that lets us print a message that
-  # includes the filename when `friends clean` is called.
-  @message = "File cleaned: \"#{filename}\"" if @clean_command
-
-  # Print the output message (if there is one) unless --quiet is passed.
-  puts @message unless @message.nil? || global_options[:quiet]
+  @introvert.clean(clean_command: @clean_command) if @dirty
 end
 
 # If an error is raised, print the message to STDERR and exit the program.

--- a/lib/friends/commands/add.rb
+++ b/lib/friends/commands/add.rb
@@ -6,8 +6,7 @@ command :add do |add|
   add.arg_name "NAME"
   add.command :friend do |add_friend|
     add_friend.action do |_, _, args|
-      friend = @introvert.add_friend(name: args.join(" "))
-      @message = "Friend added: \"#{friend.name}\""
+      @introvert.add_friend(name: args.join(" "))
       @dirty = true # Mark the file for cleaning.
     end
   end
@@ -17,15 +16,7 @@ command :add do |add|
     add.arg_name "DESCRIPTION"
     add.command event do |add_event|
       add_event.action do |_, _, args|
-        event_obj = @introvert.send("add_#{event}", serialization: args.join(" "))
-
-        # If there's no description, prompt the user for one.
-        if event_obj.description.nil? || event_obj.description.empty?
-          event_obj.description = Readline.readline(event_obj.to_s)
-          event_obj.highlight_description(introvert: @introvert)
-        end
-
-        @message = "#{event.to_s.capitalize} added: \"#{event_obj}\""
+        @introvert.send("add_#{event}", serialization: args.join(" "))
         @dirty = true # Mark the file for cleaning.
       end
     end
@@ -35,8 +26,7 @@ command :add do |add|
   add.arg_name "LOCATION"
   add.command :location do |add_location|
     add_location.action do |_, _, args|
-      location = @introvert.add_location(name: args.join(" "))
-      @message = "Location added: \"#{location.name}\""
+      @introvert.add_location(name: args.join(" "))
       @dirty = true # Mark the file for cleaning.
     end
   end
@@ -45,8 +35,7 @@ command :add do |add|
   add.arg_name "NAME NICKNAME"
   add.command :nickname do |add_nickname|
     add_nickname.action do |_, _, args|
-      friend = @introvert.add_nickname(name: args.first, nickname: args[1])
-      @message = "Nickname added: \"#{friend}\""
+      @introvert.add_nickname(name: args.first, nickname: args[1])
       @dirty = true # Mark the file for cleaning.
     end
   end
@@ -55,11 +44,10 @@ command :add do |add|
   add.arg_name "NAME @TAG"
   add.command :tag do |add_tag|
     add_tag.action do |_, _, args|
-      friend = @introvert.add_tag(
+      @introvert.add_tag(
         name: args[0..-2].join(" "),
         tag: Tag.convert_to_tag(args.last)
       )
-      @message = "Tag added to friend: \"#{friend}\""
       @dirty = true # Mark the file for cleaning.
     end
   end

--- a/lib/friends/commands/edit.rb
+++ b/lib/friends/commands/edit.rb
@@ -6,7 +6,18 @@ command :edit do |edit|
     editor = ENV["EDITOR"] || "vim"
     filename = global_options[:filename]
 
-    puts "Opening \"#{filename}\" in #{editor}" unless global_options[:quiet]
-    Kernel.exec "#{editor} #{filename}"
+    puts "Opening \"#{filename}\" with \"#{editor}\"" unless global_options[:quiet]
+
+    # Mark the file for cleaning once the editor was closed correctly.
+    if Kernel.system("#{editor} #{filename}")
+      @introvert = Friends::Introvert.new(
+        filename: global_options[:filename],
+        quiet: global_options[:quiet]
+      )
+      @clean_command = true
+      @dirty = true
+    elsif !global_options[:quiet]
+      puts "Not cleaning file: \"#{filename}\" (\"#{editor}\" did not exit successfully)"
+    end
   end
 end

--- a/lib/friends/commands/list.rb
+++ b/lib/friends/commands/list.rb
@@ -20,7 +20,7 @@ command :list do |list|
                         desc: "Output friend nicknames, locations, and tags"
 
     list_friends.action do |_, options|
-      puts @introvert.list_friends(
+      @introvert.list_friends(
         location_name: options[:in],
         tagged: options[:tagged],
         verbose: options[:verbose]
@@ -65,7 +65,7 @@ command :list do |list|
                        type: InputDate
 
       list_events.action do |_, options|
-        puts @introvert.send(
+        @introvert.send(
           "list_#{events}",
           limit: options[:limit],
           with: options[:with],
@@ -81,7 +81,7 @@ command :list do |list|
   list.desc "List all locations"
   list.command :locations do |list_locations|
     list_locations.action do
-      puts @introvert.list_locations
+      @introvert.list_locations
     end
   end
 
@@ -93,7 +93,7 @@ command :list do |list|
                          "all three",
                    multiple: true
     list_tags.action do |_, options|
-      puts @introvert.list_tags(from: options[:from])
+      @introvert.list_tags(from: options[:from])
     end
   end
 

--- a/lib/friends/commands/remove.rb
+++ b/lib/friends/commands/remove.rb
@@ -6,8 +6,7 @@ command :remove do |remove|
   remove.arg_name "NAME NICKNAME"
   remove.command :nickname do |remove_nickname|
     remove_nickname.action do |_, _, args|
-      friend = @introvert.remove_nickname(name: args.first, nickname: args[1])
-      @message = "Nickname removed: \"#{friend}\""
+      @introvert.remove_nickname(name: args.first, nickname: args[1])
       @dirty = true # Mark the file for cleaning.
     end
   end
@@ -16,11 +15,10 @@ command :remove do |remove|
   remove.arg_name "NAME @TAG"
   remove.command :tag do |remove_tag|
     remove_tag.action do |_, _, args|
-      friend = @introvert.remove_tag(
+      @introvert.remove_tag(
         name: args[0..-2].join(" "),
         tag: Tag.convert_to_tag(args.last)
       )
-      @message = "Tag removed from friend: \"#{friend}\""
       @dirty = true # Mark the file for cleaning.
     end
   end

--- a/lib/friends/commands/rename.rb
+++ b/lib/friends/commands/rename.rb
@@ -6,11 +6,10 @@ command :rename do |rename|
   rename.arg_name "NAME NEW_NAME"
   rename.command :friend do |rename_friend|
     rename_friend.action do |_, _, args|
-      friend = @introvert.rename_friend(
+      @introvert.rename_friend(
         old_name: args.first,
         new_name: args[1]
       )
-      @message = "Name changed: \"#{friend}\""
       @dirty = true # Mark the file for cleaning.
     end
   end
@@ -19,11 +18,10 @@ command :rename do |rename|
   rename.arg_name "NAME NEW_NAME"
   rename.command :location do |rename_location|
     rename_location.action do |_, _, args|
-      location = @introvert.rename_location(
+      @introvert.rename_location(
         old_name: args.first,
         new_name: args[1]
       )
-      @message = "Location renamed: \"#{location.name}\""
       @dirty = true # Mark the file for cleaning.
     end
   end

--- a/lib/friends/commands/set.rb
+++ b/lib/friends/commands/set.rb
@@ -6,8 +6,7 @@ command :set do |set|
   set.arg_name "NAME LOCATION"
   set.command :location do |set_location|
     set_location.action do |_, _, args|
-      friend = @introvert.set_location(name: args.first, location_name: args[1])
-      @message = "#{friend.name}'s location set to: #{friend.location_name}"
+      @introvert.set_location(name: args.first, location_name: args[1])
       @dirty = true # Mark the file for cleaning.
     end
   end

--- a/lib/friends/commands/stats.rb
+++ b/lib/friends/commands/stats.rb
@@ -3,12 +3,6 @@
 desc "List all stats"
 command :stats do |stats|
   stats.action do
-    puts "Total activities: #{@introvert.total_activities}"
-    puts "Total friends: #{@introvert.total_friends}"
-    puts "Total locations: #{@introvert.total_locations}"
-    puts "Total notes: #{@introvert.total_notes}"
-    puts "Total tags: #{@introvert.total_tags}"
-    days = @introvert.elapsed_days
-    puts "Total time elapsed: #{days} day#{'s' if days != 1}"
+    @introvert.stats
   end
 end

--- a/lib/friends/commands/suggest.rb
+++ b/lib/friends/commands/suggest.rb
@@ -8,13 +8,6 @@ command :suggest do |suggest|
                type: Stripped
 
   suggest.action do |_, options|
-    suggestions = @introvert.suggest(location_name: options[:in])
-
-    puts "Distant friend: "\
-      "#{Paint[suggestions[:distant].sample || 'None found', :bold, :magenta]}"
-    puts "Moderate friend: "\
-      "#{Paint[suggestions[:moderate].sample || 'None found', :bold, :magenta]}"
-    puts "Close friend: "\
-      "#{Paint[suggestions[:close].sample || 'None found', :bold, :magenta]}"
+    @introvert.suggest(location_name: options[:in])
   end
 end

--- a/lib/friends/commands/update.rb
+++ b/lib/friends/commands/update.rb
@@ -2,7 +2,7 @@
 
 desc "Updates the `friends` program"
 command :update do |update|
-  update.action do
+  update.action do |global_options|
     # rubocop:disable Lint/AssignmentInCondition
     if match = `gem search friends`.match(/^friends\s\(([^\)]+)\)$/)
       # rubocop:enable Lint/AssignmentInCondition
@@ -10,19 +10,18 @@ command :update do |update|
       if Semverse::Version.coerce(remote_version) >
          Semverse::Version.coerce(Friends::VERSION)
         `gem update friends && gem cleanup friends`
-        @message = if $?.success?
-                     Paint[
-                       "Updated to friends #{remote_version}", :bold, :green
-                     ]
-                   else
-                     Paint[
-                       "Error updating to friends version #{remote_version}", :bold, :red
-                     ]
-                   end
+
+        unless global_options[:quiet]
+          if $?.success?
+            puts Paint["Updated to friends #{remote_version}", :bold, :green]
+          else
+            puts Paint["Error updating to friends version #{remote_version}", :bold, :red]
+          end
+        end
       else
-        @message = Paint[
-          "Already up-to-date (#{Friends::VERSION})", :bold, :green
-        ]
+        unless global_options[:quiet]
+          puts Paint["Already up-to-date (#{Friends::VERSION})", :bold, :green]
+        end
       end
     end
   end

--- a/lib/friends/event.rb
+++ b/lib/friends/event.rb
@@ -156,13 +156,13 @@ module Friends
     # Find the names of all friends in this description.
     # @return [Array] list of all friend names in the description
     def friend_names
-      @_friend_names ||= @description.scan(/(?<=\*\*)\w[^\*]*(?=\*\*)/).uniq
+      @description.scan(/(?<=\*\*)\w[^\*]*(?=\*\*)/).uniq
     end
 
     # Find the names of all locations in this description.
     # @return [Array] list of all location names in the description
     def location_names
-      @_location_names ||= @description.scan(/(?<=_)\w[^_]*(?=_)/).uniq
+      @description.scan(/(?<=_)\w[^_]*(?=_)/).uniq
     end
 
     private

--- a/test/commands/clean_spec.rb
+++ b/test/commands/clean_spec.rb
@@ -3,7 +3,8 @@
 require "./test/helper"
 
 clean_describe "clean" do
-  subject { run_cmd("clean") }
+  subject { run_cmd("#{quiet} clean") }
+  let(:quiet) { nil }
   let(:content) { nil }
 
   it "outputs a message" do
@@ -34,12 +35,98 @@ clean_describe "clean" do
     end
   end
 
+  describe "when file is missing some headers and sections are out of order" do
+    let(:content) do
+      <<-CONTENT
+### Friends:
+- Marie Curie
+
+### Activities:
+- 2016-01-01: Celebrated the new year with **Marie Curie**.
+      CONTENT
+    end
+
+    it "adds the missing file structure and reorders the sections" do
+      file_equals <<-FILE
+### Activities:
+- 2016-01-01: Celebrated the new year with **Marie Curie**.
+
+### Notes:
+
+### Friends:
+- Marie Curie
+
+### Locations:
+      FILE
+    end
+  end
+
   describe "when file has content" do
     describe "when content is formatted correctly" do
       let(:content) { SCRAMBLED_CONTENT }
 
       it "writes the file with contents sorted" do
         file_equals CONTENT
+      end
+
+      describe "when the content includes friends and locations that have not yet been added" do
+        let(:content) do
+          <<-CONTENT
+### Activities:
+- 2017-01-01: Celebrated the new year in _Paris_ with **Marie Curie** and her husband **Pierre Curie**. **Marie Curie** loves _Paris_!
+
+### Notes:
+- 2017-01-01: I just learned that **Jacques Cousteau** is thinking about moving from _Gironde_ to _The Lost City of Atlantis_ (_Gironde_ did seem a bit too terrestrial for him).
+
+### Friends:
+- Grace Hopper [NYC]
+
+### Locations:
+- NYC
+          CONTENT
+        end
+
+        it "adds those friends and locations" do
+          file_equals <<-CONTENT
+### Activities:
+- 2017-01-01: Celebrated the new year in _Paris_ with **Marie Curie** and her husband **Pierre Curie**. **Marie Curie** loves _Paris_!
+
+### Notes:
+- 2017-01-01: I just learned that **Jacques Cousteau** is thinking about moving from _Gironde_ to _The Lost City of Atlantis_ (_Gironde_ did seem a bit too terrestrial for him).
+
+### Friends:
+- Grace Hopper [NYC]
+- Jacques Cousteau
+- Marie Curie
+- Pierre Curie
+
+### Locations:
+- Gironde
+- NYC
+- Paris
+- The Lost City of Atlantis
+          CONTENT
+        end
+
+        it "prints messages for both cleaning and adding friends/locations" do
+          stdout_only <<-OUTPUT
+Friend added: \"Marie Curie\"
+Friend added: \"Pierre Curie\"
+Location added: \"Paris\"
+Friend added: \"Jacques Cousteau\"
+Location added: \"Gironde\"
+Location added: \"The Lost City of Atlantis\"
+File cleaned: \"#{filename}\"
+          OUTPUT
+        end
+
+        describe "when output is quieted" do
+          let(:quiet) { "--quiet" }
+
+          it "prints no messages" do
+            stdout_only ""
+          end
+        end
       end
     end
 

--- a/test/commands/edit_spec.rb
+++ b/test/commands/edit_spec.rb
@@ -3,25 +3,133 @@
 require "./test/helper"
 
 clean_describe "edit" do
-  subject do
-    stdout, stderr, status = Open3.capture3(
-      "EDITOR=cat bundle exec bin/friends --colorless --filename #{filename} edit"
-    )
-    {
-      stdout: stdout,
-      stderr: stderr,
-      status: status.exitstatus
-    }
+  subject { run_cmd("#{quiet} edit", env_vars: "EDITOR=#{editor}") }
+
+  let(:content) { SCRAMBLED_CONTENT }
+  let(:editor) { "cat" }
+
+  # First we test some simple behavior using `cat` as our "editor."
+  describe "when output is quieted" do
+    let(:quiet) { "--quiet" }
+
+    it 'opens the file in the "editor"' do
+      stdout_only content
+    end
+
+    it "cleans the file" do
+      file_equals CONTENT # File is cleaned (no longer scrambled).
+    end
   end
 
-  let(:content) { CONTENT }
+  describe "when output is not quieted" do
+    let(:quiet) { nil }
 
-  it 'opens the file in the "editor"' do
-    # Because of the way that the edit command uses `Kernel.exec` to replace itself,
-    # our `Open3.capture3` call doesn't return STDOUT from before the `Kernel.exec`
-    # call, meaning we can't test output of the status message we print out, and
-    # our test here can check that STDOUT is equivalent to the `Kernel.exec` command's
-    # output, even though visually that's not what happens.
-    stdout_only content
+    # Since our "editor" is just `cat`, our STDOUT output will include both the opening
+    # message and the contents of the file.
+    it 'prints a message and opens the file in the "editor"' do
+      stdout_only "Opening \"#{filename}\" with \"#{editor}\""\
+                  "\n#{content}File cleaned: \"#{filename}\""
+    end
+
+    it "cleans the file" do
+      file_equals CONTENT # File is cleaned (no longer scrambled).
+    end
+  end
+
+  describe "when editor does not exit successfully" do
+    let(:editor) { "'exit 1 #'" }
+
+    describe "when output is quieted" do
+      let(:quiet) { "--quiet" }
+
+      it "prints nothing to STDOUT" do
+        stdout_only ""
+      end
+
+      it "does not clean the file" do
+        file_equals content
+      end
+    end
+
+    describe "when output is not quieted" do
+      let(:quiet) { nil }
+
+      it "prints a status message to STDOUT" do
+        stdout_only <<-OUTPUT
+Opening "#{filename}" with "exit 1 #"
+Not cleaning file: "#{filename}" ("exit 1 #" did not exit successfully)
+        OUTPUT
+      end
+
+      it "does not clean the file" do
+        file_equals content
+      end
+    end
+  end
+
+  # Now we test a more realistic scenario, in which the editor actually modifies the
+  # file. Instead of human interaction we use the `test/editor` file to serve as our
+  # editor; that script adds a new activity to the file with a friend name and location
+  # name that are not currently in the file. This tests the fact that `friends edit`
+  # should clean the `friends.md` file *after* the editor has closed successfully.
+  describe "when edit operation adds an event that includes a new friend or location" do
+    let(:editor) { "test/editor" }
+    let(:cleaned_edited_content) do
+      <<-EXPECTED_CONTENT
+### Activities:
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
+- 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
+- 2014-12-15: I just had a possible **Bigfoot** sighting! I think I may have seen **Bigfoot** in the _Mysterious Mountains_.
+- 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
+
+### Notes:
+- 2017-03-12: **Marie Curie** completed her PhD in record time. @school
+- 2015-06-15: **Grace Hopper** found out she's getting a big Naval Academy building named after her. @navy
+- 2015-06-06: **Marie Curie** just got accepted into a PhD program in _Paris_. @school
+- 2015-01-04: **Grace Hopper** and **George Washington Carver** both won an award.
+
+### Friends:
+- Bigfoot
+- George Washington Carver
+- Grace Hopper (a.k.a. The Admiral a.k.a. Amazing Grace) [Paris] @navy @science
+- Marie Curie [Atlantis] @science
+
+### Locations:
+- Atlantis
+- Marie's Diner
+- Mysterious Mountains
+- Paris
+      EXPECTED_CONTENT
+    end
+
+    describe "when output is quieted" do
+      let(:quiet) { "--quiet" }
+
+      it "prints nothing to STDOUT" do
+        stdout_only ""
+      end
+
+      it "cleans the file after the editor has quit" do
+        file_equals cleaned_edited_content
+      end
+    end
+
+    describe "when output is not quieted" do
+      let(:quiet) { nil }
+
+      it "prints status messages to STDOUT" do
+        stdout_only <<-OUTPUT
+Opening "#{filename}" with "#{editor}"
+Friend added: "Bigfoot"
+Location added: "Mysterious Mountains"
+File cleaned: "#{filename}"
+        OUTPUT
+      end
+
+      it "cleans the file after the editor has quit" do
+        file_equals cleaned_edited_content
+      end
+    end
   end
 end

--- a/test/commands/rename/friend_spec.rb
+++ b/test/commands/rename/friend_spec.rb
@@ -48,6 +48,13 @@ clean_describe "rename friend" do
       FILE
     end
 
+    it "updates friend name in notes" do
+      line_changed(
+        "- 2015-01-04: **Grace Hopper** and **George Washington Carver** both won an award.",
+        "- 2015-01-04: **Grace Hopper** and **George Washington** both won an award."
+      )
+    end
+
     it "prints an output message" do
       stdout_only 'Name changed: "George Washington"'
     end

--- a/test/commands/rename/location_spec.rb
+++ b/test/commands/rename/location_spec.rb
@@ -29,6 +29,14 @@ clean_describe "rename location" do
       )
     end
 
+    it "updates location name in notes" do
+      line_changed(
+        "- 2015-06-06: **Marie Curie** just got accepted into a PhD program in _Paris_. @school",
+        "- 2015-06-06: **Marie Curie** just got accepted into a PhD program in "\
+        "_Ville Lumière_. @school"
+      )
+    end
+
     it "updates location name for friends" do
       line_changed(
         "- Grace Hopper (a.k.a. The Admiral a.k.a. Amazing Grace) [Paris] @navy @science",

--- a/test/commands/set/location_spec.rb
+++ b/test/commands/set/location_spec.rb
@@ -31,7 +31,7 @@ clean_describe "set location" do
       let(:friend_name) { "Marie" }
 
       it "prints correct output" do
-        stdout_only "Marie Curie's location set to: Paris"
+        stdout_only "Marie Curie's location set to: \"Paris\""
       end
 
       it "updates existing location" do
@@ -43,7 +43,7 @@ clean_describe "set location" do
       let(:friend_name) { "George" }
 
       it "prints correct output" do
-        stdout_only "George Washington Carver's location set to: Paris"
+        stdout_only "George Washington Carver's location set to: \"Paris\""
       end
 
       it "adds a location" do

--- a/test/editor
+++ b/test/editor
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+# This is an example "editor" used to test the `friends edit` command.
+# It inserts a new activity into the second line of the file, allowing
+# us to test that friends and locations added in an `edit` command are
+# subsequently added during the `clean` stage after the editor closes.
+
+filename = ARGV[0]
+current_file_contents = File.read(filename).split("\n")
+File.open(filename, "w") do |file|
+  file.puts current_file_contents[0]
+  file.puts "- 2014-12-15: I just had a possible **Bigfoot** sighting! "\
+            "I think I may have seen **Bigfoot** in the _Mysterious Mountains_."
+  file.puts current_file_contents.drop(1)
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -79,9 +79,9 @@ def filename; end
 
 def subject; end
 
-def run_cmd(command, **args)
+def run_cmd(command, env_vars: "", **args)
   stdout, stderr, status = Open3.capture3(
-    "bundle exec bin/friends --colorless --filename #{filename} #{command}",
+    "#{env_vars} bundle exec bin/friends --colorless --filename #{filename} #{command}",
     **args
   )
   {


### PR DESCRIPTION
This commit adds the ability to add new friends and locations
directly from `add activity` and `add note` by simply using the
`**` or `_` signifiers as they are in the file. This is especially
useful for manual edits via `friends edit`.

As a part of this change:
- Commands have been restructured to do all printing inside
  Introvert as opposed to in the GLI blocks.
- `friends edit` now waits until the editing is complete and
  then runs `friends clean`
- A bug whereby `rename` commands didn't update notes has been
  fixed.

Resolves #189 and #182

---

Hi there! Thanks so much for submitting a pull request!

Let's just make sure together that all of these boxes are checked before we
merge this change:

- [x] The code in these changes works correctly.
- [x] Code has tests as appropriate.
- [x] Code has been reviewed by @JacobEvelyn.
- [x] All tests pass on Travis CI.
- [x] Rubocop reports no issues on Travis CI.
- [x] The `README.md` file is updated as appropriate.

Don't worry—this list will get checked off in no time!
