### PR TITLE
Fix file-reading issues with default file

### DIFF
--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -23,7 +23,8 @@ module Friends
 
     # @param filename [String] the name of the friends Markdown file
     def initialize(filename:)
-      @filename = filename
+      @user_facing_filename = filename
+      @expanded_filename = File.expand_path(filename)
       @output = []
 
       # Read in the input file. It's easier to do this now and optimize later
@@ -59,7 +60,7 @@ module Friends
         end
       end
 
-      File.open(File.expand_path(@filename), "w") do |file|
+      File.open(@expanded_filename, "w") do |file|
         file.puts(ACTIVITIES_HEADER)
         stable_sort(@activities).each { |act| file.puts(act.serialize) }
         file.puts # Blank line separating activities from notes.
@@ -75,7 +76,7 @@ module Friends
 
       # This is a special-case piece of code that lets us print a message that
       # includes the filename when `friends clean` is called.
-      @output << "File cleaned: \"#{@filename}\"" if clean_command
+      @output << "File cleaned: \"#{@user_facing_filename}\"" if clean_command
     end
 
     # Add a friend.
@@ -665,12 +666,12 @@ module Friends
       @notes = []
       @locations = []
 
-      return unless File.exist?(@filename)
+      return unless File.exist?(@expanded_filename)
 
       state = :unknown
 
       # Loop through all lines in the file and process them.
-      File.foreach(@filename).with_index(1) do |line, line_num|
+      File.foreach(@expanded_filename).with_index(1) do |line, line_num|
         line.chomp! # Remove trailing newline from each line.
 
         # Parse the line and update the parsing state.

--- a/test/default_file_spec.rb
+++ b/test/default_file_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "./test/helper"
+
+# Since this touches the ~/friends.md file instead of a temp
+# one, we only want to run it on our CI servers.
+if ENV["TRAVIS"] == "true"
+  describe "default filename behavior" do
+    let(:filename) { File.expand_path("~/friends.md") }
+
+    after { File.delete(filename) }
+
+    # Since the filename is the system-wide one, we can't have
+    # more than one test that touches it, because multiple
+    # tests can run in parallel and might stomp on one another.
+    # Instead, we just run one test that exercises a lot.
+    # This test specifically checks for regressions akin to
+    # https://github.com/JacobEvelyn/friends/issues/231
+    it "creates a new file and adds to it multiple times" do
+      # File does not exist at first.
+      File.exist?(filename).must_equal false
+
+      `bundle exec bin/friends add friend Mohandas Karamchand Gandhi`
+      `bundle exec bin/friends add friend Sojourner Truth`
+      `bundle exec bin/friends add activity 1859-11-30: Lunch with **Harriet Tubman** in _Auburn_.`
+      `bundle exec bin/friends add note "1851-05-29: Sojourner Truth's speech"`
+
+      File.read(filename).must_equal <<-FILE
+### Activities:
+- 1859-11-30: Lunch with **Harriet Tubman** in _Auburn_.
+
+### Notes:
+- 1851-05-29: **Sojourner Truth**'s speech
+
+### Friends:
+- Harriet Tubman
+- Mohandas Karamchand Gandhi
+- Sojourner Truth
+
+### Locations:
+- Auburn
+      FILE
+    end
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -139,8 +139,8 @@ def line_added(expected)
   lines.size.must_equal(n_initial_lines + 1) # Line was added, not changed.
 end
 
-def clean_describe(desc, *additional_desc, &block)
-  describe desc, *additional_desc do
+def clean_describe(desc, &block)
+  describe desc do
     let(:filename) { "test/tmp/friends#{SecureRandom.uuid}.md" }
 
     before { File.write(filename, content) unless content.nil? }


### PR DESCRIPTION
This commit fixes a serious bug in which, when
no `--filename` flag was passed, the program would
be unable to read the file and would therefore
write over it as though it had not existed.

Fixes #231

---

Hi there! Thanks so much for submitting a pull request!

Let's just make sure together that all of these boxes are checked before we
merge this change:

- [x] The code in these changes works correctly.
- [x] Code has tests as appropriate.
- [x] Code has been reviewed by @JacobEvelyn.
- [x] All tests pass on Travis CI.
- [x] Code coverage remains high.
- [x] Rubocop reports no issues on Travis CI.
- [x] The `README.md` file is updated as appropriate.

Don't worry—this list will get checked off in no time!
