### PR TITLE
Add `bundle exec` to readme in section for running tests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Here's what to do:
 5. Create your feature branch
    (`git checkout -b my-new-feature`).
 6. Make your changes. Add or modify tests if necessary!
-   (Run tests with `rake test`.) Do your best to conform to
+   (Run tests with `bundle exec rake test`.) Do your best to conform to
    existing style and commenting patterns. You can run the local version of the
    `friends` script with `bundle exec bin/friends`.
 7. Update the `README.md` as necessary to include your changes.


### PR DESCRIPTION
When running `rake test`, one test keeps failing, complaining that it doesn't have access to the `Friends::POST_INSTALL_MESSAGE` module. However, when running `bundle exec rake test`, the test does not fail. I suspect this is because using `bundle exec` loads the `gemspec` which itself includes the module explicitly (via `require "friends/post_install_message"`).

I have therefore updated the readme to use `bundle exec rake test` when running tests :)

---

Hi there! Thanks so much for submitting a pull request!

Let's just make sure together that all of these boxes are checked before we
merge this change:

- [x] The code in these changes works correctly.
- [x] Code has tests as appropriate.
- [x] Code has been reviewed by @JacobEvelyn.
- [x] All tests pass on Travis CI.
- [x] Code coverage remains high.
- [x] Rubocop reports no issues on Travis CI.
- [x] The `README.md` file is updated as appropriate.

Don't worry—this list will get checked off in no time!
