### PR TITLE
Separate optional test dependencies with Gemfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ rvm:
   - 2.3
   - 2.4
   - 2.5 # 2.6 is tested below
+gemfile: Gemfile.old # The latest Ruby version uses Gemfile below
 script:
   - bundle exec rake test
 matrix:
   include:
     - rvm: 2.6
+      gemfile: Gemfile
       script:
         - bundle exec rake test
         - gem install --no-document rubocop -v 0.67 && rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,14 @@
 source "https://rubygems.org"
 
 gemspec
+
+group :development, :test do
+  gem "rubocop", "0.67"
+end
+
+group :test do
+  gem "codecov", "~> 0.1.14"
+  gem "simplecov",
+      git: "https://github.com/colszowka/simplecov",
+      ref: "cb968abf857a704364283b5dec4d9fa3d096287e"
+end

--- a/Gemfile.old
+++ b/Gemfile.old
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec

--- a/bin/friends
+++ b/bin/friends
@@ -3,6 +3,7 @@
 
 if ENV["TRAVIS"] == "true" && ENV["CODE_COVERAGE"] == "true"
   require "simplecov"
+  SimpleCov.print_error_status = false
   SimpleCov.formatter = SimpleCov::Formatter::SimpleFormatter
   SimpleCov.command_name Process.pid.to_s
   SimpleCov.start

--- a/friends.gemspec
+++ b/friends.gemspec
@@ -33,10 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "semverse", ">= 2", "< 4"
   spec.add_dependency "tty-pager", "~> 0.11"
 
-  spec.add_development_dependency "bundler", ">= 1.6"
-  spec.add_development_dependency "codecov", "~> 0.1.14"
   spec.add_development_dependency "minitest", "~> 5.5"
   spec.add_development_dependency "minitest-proveit", "~> 1.0"
   spec.add_development_dependency "rake", "~> 12.3"
-  spec.add_development_dependency "simplecov", "~> 0.14"
 end

--- a/test/add_event_helper.rb
+++ b/test/add_event_helper.rb
@@ -56,7 +56,7 @@ def description_parsing_specs(test_stdout: true)
         let(:description) { "  " }
 
         it "prints an error message" do
-          subject[:stderr].must_equal(
+          value(subject[:stderr]).must_equal(
             ensure_trailing_newline_unless_empty("Error: Blank #{event} not added")
           )
         end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -32,7 +32,7 @@ FILE
 
     it "orders dates by insertion time" do
       subject
-      File.read(filename).must_equal <<-FILE
+      value(File.read(filename)).must_equal <<-FILE
 ### Activities:
 - 2018-01-01: Activity one year later.
 - 2017-01-01: Activity 5.

--- a/test/commands/add/note_spec.rb
+++ b/test/commands/add/note_spec.rb
@@ -32,7 +32,7 @@ FILE
 
     it "orders dates by insertion time" do
       subject
-      File.read(filename).must_equal <<-FILE
+      value(File.read(filename)).must_equal <<-FILE
 ### Activities:
 
 ### Notes:

--- a/test/commands/clean_spec.rb
+++ b/test/commands/clean_spec.rb
@@ -15,7 +15,7 @@ clean_describe "clean" do
     let(:content) { nil }
 
     it "does not create the file" do
-      File.exist?(filename).must_equal false
+      value(File.exist?(filename)).must_equal false
     end
   end
 

--- a/test/commands/help_spec.rb
+++ b/test/commands/help_spec.rb
@@ -8,15 +8,17 @@ clean_describe "help" do
 
   describe "with no subcommand passed" do
     it "prints overall help message" do
-      subject[:stderr].must_equal ""
-      subject[:status].must_equal 0
-      [
-        "NAME",
-        "SYNOPSIS",
-        "VERSION",
-        "GLOBAL OPTIONS",
-        "COMMANDS"
-      ].all? { |msg| subject[:stdout].include? msg }.must_equal true
+      value(subject[:stderr]).must_equal ""
+      value(subject[:status]).must_equal 0
+      value(
+        [
+          "NAME",
+          "SYNOPSIS",
+          "VERSION",
+          "GLOBAL OPTIONS",
+          "COMMANDS"
+        ].all? { |msg| subject[:stdout].include? msg }
+      ).must_equal true
     end
   end
 
@@ -24,13 +26,15 @@ clean_describe "help" do
     subject { run_cmd("help graph") }
 
     it "prints subcommand help message" do
-      subject[:stderr].must_equal ""
-      subject[:status].must_equal 0
-      [
-        "NAME",
-        "SYNOPSIS",
-        "COMMAND OPTIONS"
-      ].all? { |msg| subject[:stdout].include? msg }.must_equal true
+      value(subject[:stderr]).must_equal ""
+      value(subject[:status]).must_equal 0
+      value(
+        [
+          "NAME",
+          "SYNOPSIS",
+          "COMMAND OPTIONS"
+        ].all? { |msg| subject[:stdout].include? msg }
+      ).must_equal true
     end
   end
 

--- a/test/commands/list/favorite/friends_spec.rb
+++ b/test/commands/list/favorite/friends_spec.rb
@@ -79,34 +79,34 @@ FILE
       end
 
       it "uses tied ranks" do
-        subject[:stderr].must_equal ""
-        subject[:status].must_equal 0
+        value(subject[:stderr]).must_equal ""
+        value(subject[:status]).must_equal 0
 
         lines = subject[:stdout].split("\n")
-        lines[1].must_match(/1\. Friend (A|B)/)
-        lines[2].must_match(/1\. Friend (A|B)/)
-        lines[3].must_include "3. Friend"
+        value(lines[1]).must_match(/1\. Friend (A|B)/)
+        value(lines[2]).must_match(/1\. Friend (A|B)/)
+        value(lines[3]).must_include "3. Friend"
       end
 
       it "only uses the word 'activities' for the first item, even when a tie" do
-        subject[:stderr].must_equal ""
-        subject[:status].must_equal 0
+        value(subject[:stderr]).must_equal ""
+        value(subject[:status]).must_equal 0
 
         lines = subject[:stdout].split("\n")
-        lines[1].must_include "activities"
-        lines[2].wont_include "activities"
+        value(lines[1]).must_include "activities"
+        value(lines[2]).wont_include "activities"
       end
 
       it "indents based on the highest rank number, not the number of friends" do
-        subject[:stderr].must_equal ""
-        subject[:status].must_equal 0
+        value(subject[:stderr]).must_equal ""
+        value(subject[:status]).must_equal 0
 
         # Since there are 10 friends, a naive implementation would pad our output
         # assuming the (numerically) highest rank is "10." but since the highest
         # rank is a tie, we never display a double-digit rank, so we don't need to
         # pad our output for double digits.
         lines = subject[:stdout].split("\n")
-        lines.last.must_include "3. Friend"
+        value(lines.last).must_include "3. Friend"
       end
     end
   end

--- a/test/commands/list/favorite/locations_spec.rb
+++ b/test/commands/list/favorite/locations_spec.rb
@@ -84,34 +84,34 @@ FILE
       end
 
       it "uses tied ranks" do
-        subject[:stderr].must_equal ""
-        subject[:status].must_equal 0
+        value(subject[:stderr]).must_equal ""
+        value(subject[:status]).must_equal 0
 
         lines = subject[:stdout].split("\n")
-        lines[1].must_match(/1\. Location (A|B)/)
-        lines[2].must_match(/1\. Location (A|B)/)
-        lines[3].must_include "3. Location"
+        value(lines[1]).must_match(/1\. Location (A|B)/)
+        value(lines[2]).must_match(/1\. Location (A|B)/)
+        value(lines[3]).must_include "3. Location"
       end
 
       it "only uses the word 'activities' for the first item, even when a tie" do
-        subject[:stderr].must_equal ""
-        subject[:status].must_equal 0
+        value(subject[:stderr]).must_equal ""
+        value(subject[:status]).must_equal 0
 
         lines = subject[:stdout].split("\n")
-        lines[1].must_include "activities"
-        lines[2].wont_include "activities"
+        value(lines[1]).must_include "activities"
+        value(lines[2]).wont_include "activities"
       end
 
       it "indents based on the highest rank number, not the number of locations" do
-        subject[:stderr].must_equal ""
-        subject[:status].must_equal 0
+        value(subject[:stderr]).must_equal ""
+        value(subject[:status]).must_equal 0
 
         # Since there are 10 friends, a naive implementation would pad our output
         # assuming the (numerically) highest rank is "10." but since the highest
         # rank is a tie, we never display a double-digit rank, so we don't need to
         # pad our output for double digits.
         lines = subject[:stdout].split("\n")
-        lines.last.must_include "3. Location"
+        value(lines.last).must_include "3. Location"
       end
     end
   end

--- a/test/commands/rename/friend_spec.rb
+++ b/test/commands/rename/friend_spec.rb
@@ -33,7 +33,7 @@ clean_describe "rename friend" do
     end
 
     it "updates friend name in activities" do
-      run_cmd("list activities")[:stdout].must_equal <<-FILE
+      value(run_cmd("list activities")[:stdout]).must_equal <<-FILE
 2018-02-06: @science:indoors:agronomy-with-hydroponics: Norman Borlaug and George Washington Carver scored a tour of Atlantis' hydroponics gardens through wetplants@example.org and they took me along.
 2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute. @food
 2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
@@ -41,7 +41,7 @@ clean_describe "rename friend" do
 2014-11-15: Talked to George Washington Carver on the phone for an hour.
       FILE
       subject
-      run_cmd("list activities")[:stdout].must_equal <<-FILE
+      value(run_cmd("list activities")[:stdout]).must_equal <<-FILE
 2018-02-06: @science:indoors:agronomy-with-hydroponics: Norman Borlaug and George Washington scored a tour of Atlantis' hydroponics gardens through wetplants@example.org and they took me along.
 2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute. @food
 2015-01-04: Got lunch with Grace Hopper and George Washington. @food

--- a/test/commands/update_spec.rb
+++ b/test/commands/update_spec.rb
@@ -7,14 +7,16 @@ clean_describe "update" do
   let(:content) { nil }
 
   it "prints a status message" do
-    subject[:stderr].must_equal ""
-    subject[:status].must_equal 0
-    [/Updated to friends/, /Already up-to-date/].one? { |m| subject[:stdout] =~ m }.must_equal true
+    value(subject[:stderr]).must_equal ""
+    value(subject[:status]).must_equal 0
+    value(
+      [/Updated to friends/, /Already up-to-date/].one? { |m| subject[:stdout] =~ m }
+    ).must_equal true
   end
 
   it "prints the post-install message" do
-    subject[:stderr].must_equal ""
-    subject[:status].must_equal 0
-    subject[:stdout].must_include Friends::POST_INSTALL_MESSAGE
+    value(subject[:stderr]).must_equal ""
+    value(subject[:status]).must_equal 0
+    value(subject[:stdout]).must_include Friends::POST_INSTALL_MESSAGE
   end
 end

--- a/test/default_file_spec.rb
+++ b/test/default_file_spec.rb
@@ -18,14 +18,14 @@ if ENV["TRAVIS"] == "true"
     # https://github.com/JacobEvelyn/friends/issues/231
     it "creates a new file and adds to it multiple times" do
       # File does not exist at first.
-      File.exist?(filename).must_equal false
+      value(File.exist?(filename)).must_equal false
 
       `bundle exec bin/friends add friend Mohandas Karamchand Gandhi`
       `bundle exec bin/friends add friend Sojourner Truth`
       `bundle exec bin/friends add activity 1859-11-30: Lunch with **Harriet Tubman** in _Auburn_.`
       `bundle exec bin/friends add note "1851-05-29: Sojourner Truth's speech"`
 
-      File.read(filename).must_equal <<-FILE
+      value(File.read(filename)).must_equal <<-FILE
 ### Activities:
 - 1859-11-30: Lunch with **Harriet Tubman** in _Auburn_.
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -108,35 +108,35 @@ end
 
 def stdout_only(expected)
   puts subject[:stderr] unless subject[:stderr] == ""
-  subject[:stdout].must_equal ensure_trailing_newline_unless_empty(expected)
-  subject[:stderr].must_equal ""
-  subject[:status].must_equal 0
+  value(subject[:stdout]).must_equal ensure_trailing_newline_unless_empty(expected)
+  value(subject[:stderr]).must_equal ""
+  value(subject[:status]).must_equal 0
 end
 
 def stderr_only(expected)
-  subject[:stdout].must_equal ""
-  subject[:stderr].must_equal ensure_trailing_newline_unless_empty(expected)
-  subject[:status].must_be :>, 0
+  value(subject[:stdout]).must_equal ""
+  value(subject[:stderr]).must_equal ensure_trailing_newline_unless_empty(expected)
+  value(subject[:status]).must_be :>, 0
 end
 
 def file_equals(expected)
   subject
-  File.read(filename).must_equal expected
+  value(File.read(filename)).must_equal expected
 end
 
 def line_changed(expected_old, expected_new)
   index = File.read(filename).split("\n").index(expected_old)
-  index.must_be_kind_of Numeric # Not nil, so we know that `expected_old` was found.
+  value(index).must_be_kind_of Numeric # Not nil, so we know that `expected_old` was found.
   subject
-  File.read(filename).split("\n")[index].must_equal expected_new
+  value(File.read(filename).split("\n")[index]).must_equal expected_new
 end
 
 def line_added(expected)
   n_initial_lines = File.read(filename).split("\n").size
   subject
   lines = File.read(filename).split("\n")
-  lines.index(expected).must_be_kind_of Numeric # Not nil, so we know that `expected` was found.
-  lines.size.must_equal(n_initial_lines + 1) # Line was added, not changed.
+  value(lines.index(expected)).must_be_kind_of Numeric # Not nil, so we know `expected` was found.
+  value(lines.size).must_equal(n_initial_lines + 1) # Line was added, not changed.
 end
 
 def clean_describe(desc, &block)


### PR DESCRIPTION
This commit adds a `Gemfile.old` which is used for testing
old Ruby versions in Travis. This file does not include
dependencies such as Rubocop and SimpleCov that are only
used in either local development or our Travis build for
the latest Ruby version.

Included in these changes is pinning the SimpleCov dependency
to the version fixed by
https://github.com/colszowka/simplecov/pull/747 to fix tests.

[@Shen-Sat](https://github.com/shen-sat) was instrumental in
discussing these changes and coming up with many parts of
the overall approach. Many thanks!

Fixes #238

---

Hi there! Thanks so much for submitting a pull request!

Let's just make sure together that all of these boxes are checked before we
merge this change:

- [x] The code in these changes works correctly.
- [x] Code has tests as appropriate.
- [x] Code has been reviewed by @JacobEvelyn.
- [x] All tests pass on Travis CI.
- [x] Code coverage remains high.
- [x] Rubocop reports no issues on Travis CI.
- [x] The `README.md` file is updated as appropriate.

Don't worry—this list will get checked off in no time!
