### PR TITLE
152/add set home command to set your own location

### DIFF
--- a/lib/friends/event.rb
+++ b/lib/friends/event.rb
@@ -64,6 +64,7 @@ module Friends
 
     attr_reader :date
     attr_accessor :description
+    attr_writer :implicit_location
 
     # @return [String] the command-line display text for the activity
     def to_s
@@ -132,9 +133,13 @@ module Friends
     end
 
     # @param location [Location] the location to test
-    # @return [Boolean] true iff this activity includes the given location
+    # @return [Boolean] true if activity has location in description or it equals implicit location
     def includes_location?(location)
-      @description.scan(/(?<=_)[^_]+(?=_)/).include? location.name
+      location_in_description?(location) || location_is_implicit?(location)
+    end
+
+    def moved_to_location
+      @description[/(?<=[mM]oved to _)\w[^_]*(?=_)/]
     end
 
     # @param friend [Friend] the friend to test
@@ -162,8 +167,13 @@ module Friends
 
     # Find the names of all locations in this description.
     # @return [Array] list of all location names in the description
-    def location_names
+    def description_location_names
       @description.scan(/(?<=_)\w[^_]*(?=_)/).uniq
+    end
+
+    # @return [Array] list of all location names in either description or implicit_location
+    def location_names
+      @implicit_location ? [@implicit_location] : description_location_names
     end
 
     private
@@ -329,6 +339,14 @@ module Friends
     # Default sorting for an array of activities is reverse-date.
     def <=>(other)
       other.date <=> date
+    end
+
+    def location_in_description?(location)
+      description_location_names.include? location.name
+    end
+
+    def location_is_implicit?(location)
+      @implicit_location == location.name
     end
   end
 end

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -52,7 +52,7 @@ module Friends
           end
         end
 
-        event.location_names.each do |name|
+        event.description_location_names.each do |name|
           unless location_names.include? name
             add_location(name: name)
             location_names << name
@@ -658,6 +658,14 @@ module Friends
       end
     end
 
+    def set_implicit_locations!
+      implicit_location = nil
+      @activities.reverse_each do |activity|
+        implicit_location = activity.moved_to_location if activity.moved_to_location
+        activity.implicit_location = implicit_location if activity.description_location_names.empty?
+      end
+    end
+
     # Process the friends.md file and store its contents in internal data
     # structures.
     def read_file
@@ -677,6 +685,7 @@ module Friends
         # Parse the line and update the parsing state.
         state = parse_line!(line, line_num: line_num, state: state)
       end
+      set_implicit_locations!
 
       set_n_activities!(:friend)
       set_n_activities!(:location)

--- a/test/commands/clean_spec.rb
+++ b/test/commands/clean_spec.rb
@@ -74,6 +74,7 @@ clean_describe "clean" do
           <<-CONTENT
 ### Activities:
 - 2017-01-01: Celebrated the new year in _Paris_ with **Marie Curie** and her husband **Pierre Curie**. **Marie Curie** loves _Paris_!
+- 2016-12-31: Moved to _London_.
 
 ### Notes:
 - 2017-01-01: I just learned that **Jacques Cousteau** is thinking about moving from _Gironde_ to _The Lost City of Atlantis_ (_Gironde_ did seem a bit too terrestrial for him).
@@ -90,6 +91,7 @@ clean_describe "clean" do
           file_equals <<-CONTENT
 ### Activities:
 - 2017-01-01: Celebrated the new year in _Paris_ with **Marie Curie** and her husband **Pierre Curie**. **Marie Curie** loves _Paris_!
+- 2016-12-31: Moved to _London_.
 
 ### Notes:
 - 2017-01-01: I just learned that **Jacques Cousteau** is thinking about moving from _Gironde_ to _The Lost City of Atlantis_ (_Gironde_ did seem a bit too terrestrial for him).
@@ -102,6 +104,7 @@ clean_describe "clean" do
 
 ### Locations:
 - Gironde
+- London
 - NYC
 - Paris
 - The Lost City of Atlantis
@@ -113,6 +116,7 @@ clean_describe "clean" do
 Friend added: \"Marie Curie\"
 Friend added: \"Pierre Curie\"
 Location added: \"Paris\"
+Location added: \"London\"
 Friend added: \"Jacques Cousteau\"
 Location added: \"Gironde\"
 Location added: \"The Lost City of Atlantis\"

--- a/test/commands/list/activities_spec.rb
+++ b/test/commands/list/activities_spec.rb
@@ -52,8 +52,38 @@ clean_describe "list activities" do
           stdout_only "2014-12-31: Celebrated the new year in Paris with Marie Curie. @partying"
         end
       end
-    end
 
+      describe "when implicit location is set" do
+        let(:location_name) { "atlantis" }
+        let(:content) do
+          <<-FILE
+### Activities:
+- 2015-01-30: Went to a museum with **George Washington Carver**.
+- 2015-01-29: moved to _Paris_.
+- 2015-01-01: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
+- 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying @food
+- 2014-12-30: Moved to _Atlantis_.
+- 2014-12-29: Talked to **George Washington Carver** on the phone for an hour.
+
+### Friends:
+- George Washington Carver
+- Marie Curie [Atlantis] @science
+- Grace Hopper (a.k.a. The Admiral a.k.a. Amazing Grace) [Paris] @navy @science
+
+### Locations:
+- Atlantis
+- Paris
+          FILE
+        end
+
+        it "matches location case-insensitively" do
+          stdout_only <<-OUTPUT
+2015-01-01: Got lunch with Grace Hopper and George Washington Carver. @food
+2014-12-30: Moved to Atlantis.
+        OUTPUT
+        end
+      end
+    end
     describe "--with" do
       subject { run_cmd("list activities --with #{friend_name}") }
 

--- a/test/commands/list/favorite/locations_spec.rb
+++ b/test/commands/list/favorite/locations_spec.rb
@@ -114,5 +114,36 @@ FILE
         value(lines.last).must_include "3. Location"
       end
     end
+
+    describe "when implied locations are set" do
+      let(:content) do
+        <<-FILE
+### Activities:
+- 2015-01-30: Went to a museum with **George Washington Carver**.
+- 2015-01-29: moved to _Paris_.
+- 2015-01-01: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
+- 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying @food
+- 2014-12-30: Moved to _Atlantis_.
+- 2014-12-29: Talked to **George Washington Carver** on the phone for an hour.
+
+### Friends:
+- George Washington Carver
+- Marie Curie [Atlantis] @science
+- Grace Hopper (a.k.a. The Admiral a.k.a. Amazing Grace) [Paris] @navy @science
+
+### Locations:
+- Atlantis
+- Paris
+        FILE
+      end
+
+      it "lists locations in order of decreasing activity" do
+        stdout_only <<-OUTPUT
+Your favorite locations:
+1. Paris    (3 activities)
+2. Atlantis (2)
+        OUTPUT
+      end
+    end
   end
 end


### PR DESCRIPTION
Hey @JacobEvelyn - apologies for the delay in getting this done! Busy with the hustle and grid of life :)

I've added the implementation discussed in: https://github.com/JacobEvelyn/friends/issues/152

Summary of changes:

- `Event` now has an `implicit_location` attribute
- When `friends.md` is read, if an activity includes the words `moved to _LOCATION_`, then LOCATION is saved and applied as the `implicit_location` for any subsequent activities that don't have a location in their description (ie that don't have an explicit location).
- If another `moved to _LOCATION_ ` activity exists further along in the `friends.md` activity timeline, then this new LOCATION is set as the `implicit_location` for subsequent activities without an explicit location.
- If the activity `moved to _LOCATION_` does not appear in `friends.md`, then activities that don’t have an explicit location do not have an `implicit_location` set.

This feature has been tested to work with `friends list activities —in` and `friends list favourite locations` commands. 

We originally agreed on `to _LOCATION_` as the key words to trigger saving and applying `implicit_location`, but this would mean phrases like `went to _Marie's Diner_` would mistakenly get picked up and set as the `implicit_location` - hence I've changed the key words to `moved to _LOCATION_`, which is more explicit/specific.

I've redefined `CONTENT` specific for the tests - I tried to use the existing definition of `CONTENT`, but it was proving too tricky. I needed `CONTENT` that would have multiple `moved to _LOCATION_` lines to test that `implicit_location` is set in the correct way.

---

Hi there! Thanks so much for submitting a pull request!

Let's just make sure together that all of these boxes are checked before we
merge this change:

- [ ] The code in these changes works correctly.
- [ ] Code has tests as appropriate.
- [ ] Code has been reviewed by @JacobEvelyn.
- [ ] All tests pass on Travis CI.
- [ ] Code coverage remains high.
- [ ] Rubocop reports no issues on Travis CI.
- [ ] The `README.md` file is updated as appropriate.

Don't worry—this list will get checked off in no time!
