### PR TITLE
152/change trigger for setting implicit location

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ FRIENDS_PAGER="less -RF"
 - **Friends**: The people you do _activities_ with. Each friend has a name and,
   optionally, one or several nicknames. (Examples: `John`, `Grace Hopper`)
 - **Locations**: The places in which _activities_ happen. (Examples: `Paris`,
-  `Marie's Diner`)
+  `Martha's Vineyard`)
 - **Tags**: A way to categorize your _activities_ with tags of your
   choosing. Tags may contain colons and hyphens inside them. (Examples: `@exercise:running`, `@school`, `@science:indoors:agronomy-with-hydroponics`)
 - **Notes**: Any additional information you want to record about a _friend_
@@ -156,7 +156,7 @@ The `friends.md` Markdown file that stores all of your data contains:
 ### Locations:
 
 - Atlantis
-- Marie's Diner
+- Martha's Vineyard
 - Paris
 ```
 
@@ -175,7 +175,7 @@ The `friends.md` Markdown file that stores all of your data contains:
 ```markdown
 ### Activities:
 
-- 2018-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
+- 2018-11-01: **Grace Hopper** and I went to _Martha's Vineyard_. George had to cancel at the last minute.
 - 2018-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**.
 - 2017-12-31: Celebrated the new year in _Paris_ with **Marie Curie**.
 - 2017-11-15: Talked to **George Washington Carver** on the phone for an hour.
@@ -340,8 +340,8 @@ $ friends add activity last Monday
 You can escape the names of friends you don't want `friends` to match with a backslash:
 
 ```bash
-$ friends add activity "2018-11-01: Grace and I went to \Marie's Diner. \George had to cancel at the last minute."
-Activity added: "2018-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute."
+$ friends add activity "2018-11-01: Grace and I went to \Martha's Vineyard. \George had to cancel at the last minute."
+Activity added: "2018-11-01: Grace Hopper and I went to Martha's Vineyard. George had to cancel at the last minute."
 ```
 
 And if an activity contains friends or locations you haven't yet added, you can simply

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ $ friends add nickname "Grace Hopper" "Amazing Grace"
 Nickname added: "Grace Hopper (a.k.a. The Admiral a.k.a. Amazing Grace)"
 ```
 
-#### Add a default location
+#### Setting a default location
 
 You can set a default location in`friends`. Thereafter, whenever an activity is added and does not mention a location, the activity will be automatically 'tagged' with the default location.
 

--- a/README.md
+++ b/README.md
@@ -426,13 +426,14 @@ Nickname added: "Grace Hopper (a.k.a. The Admiral a.k.a. Amazing Grace)"
 When an activity includes the phrase to \_LOCATION\_ (e.g., Took a plane to \_Paris\_), all future activities that have no explicit location will be associated with that location:
 
 ```bash
-$ friends add activity Took a plane to _Paris_
+$ friends add activity Took a plane to Paris
 Activity added: "2020-01-04: Took a plane to Paris"
 Default location set to: "Paris"
 $ friends add activity Ate lunch at a charming café
 Activity added: "2020-01-04: Ate lunch at a charming café"
-$ friends add activity Left the city to go to _Chamonix_
+$ friends add activity Left the city to go to Chamonix
 Activity added: "2020-01-04: Left the city to go to Chamonix"
+Default location set to: "Chamonix"
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ FRIENDS_PAGER="less -RF"
 - **Friends**: The people you do _activities_ with. Each friend has a name and,
   optionally, one or several nicknames. (Examples: `John`, `Grace Hopper`)
 - **Locations**: The places in which _activities_ happen. (Examples: `Paris`,
-  `Atlantis`)
+  `Marie's Diner`)
 - **Tags**: A way to categorize your _activities_ with tags of your
   choosing. Tags may contain colons and hyphens inside them. (Examples: `@exercise:running`, `@school`, `@science:indoors:agronomy-with-hydroponics`)
 - **Notes**: Any additional information you want to record about a _friend_
@@ -156,6 +156,7 @@ The `friends.md` Markdown file that stores all of your data contains:
 ### Locations:
 
 - Atlantis
+- Marie's Diner
 - Paris
 ```
 
@@ -174,7 +175,7 @@ The `friends.md` Markdown file that stores all of your data contains:
 ```markdown
 ### Activities:
 
-- 2018-11-01: **Grace Hopper** and I went to Marie's Diner. George had to cancel at the last minute.
+- 2018-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
 - 2018-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**.
 - 2017-12-31: Celebrated the new year in _Paris_ with **Marie Curie**.
 - 2017-11-15: Talked to **George Washington Carver** on the phone for an hour.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ FRIENDS_PAGER="less -RF"
 - **Friends**: The people you do _activities_ with. Each friend has a name and,
   optionally, one or several nicknames. (Examples: `John`, `Grace Hopper`)
 - **Locations**: The places in which _activities_ happen. (Examples: `Paris`,
-  `Marie's Diner`)
+  `Atlantis`)
 - **Tags**: A way to categorize your _activities_ with tags of your
   choosing. Tags may contain colons and hyphens inside them. (Examples: `@exercise:running`, `@school`, `@science:indoors:agronomy-with-hydroponics`)
 - **Notes**: Any additional information you want to record about a _friend_
@@ -155,7 +155,6 @@ The `friends.md` Markdown file that stores all of your data contains:
 ### Locations:
 
 - Atlantis
-- Marie's Diner
 - Paris
 ```
 
@@ -174,7 +173,7 @@ The `friends.md` Markdown file that stores all of your data contains:
 ```markdown
 ### Activities:
 
-- 2018-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
+- 2018-11-01: **Grace Hopper** and I went to Marie's Diner. George had to cancel at the last minute.
 - 2018-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**.
 - 2017-12-31: Celebrated the new year in _Paris_ with **Marie Curie**.
 - 2017-11-15: Talked to **George Washington Carver** on the phone for an hour.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ lots of help), and give feedback! This project is
       - [`add tag`](#add-tag)
       - [`add location`](#add-location)
       - [`add nickname`](#add-nickname)
+      - [Adding a default location](#adding-a-default-location)
     - [`clean`](#clean)
     - [`graph`](#graph)
     - [`help`](#help)
@@ -417,6 +418,31 @@ $ friends add nickname "Grace Hopper" "The Admiral"
 Nickname added: "Grace Hopper (a.k.a. The Admiral)
 $ friends add nickname "Grace Hopper" "Amazing Grace"
 Nickname added: "Grace Hopper (a.k.a. The Admiral a.k.a. Amazing Grace)"
+```
+
+#### Add a default location
+
+You can set a default location in`friends`. Thereafter, whenever an activity is added and does not mention a location, the activity will be automatically 'tagged' with the default location.
+
+To set a default location, use the phrase `to location` (eg `moved to Paris`), when adding an activity:
+
+```bash
+$ friends add activity Moved to Paris
+Activity added: "2018-01-04: Moved to Paris”
+Default location added: “Paris”
+```
+
+Then, when subsequent activities are added without an explicit location, friends will automatically tag the activity with the default location:
+
+```bash
+$ friends add activity Went to a cafe with George
+Activity added: "2018-01-04: Went to a cafe with George
+```
+
+```bash
+$ friends list activities --in “Paris”
+2018-01-04: Went to a cafe with George
+2018-01-04: Moved to Paris
 ```
 
 #### `clean`

--- a/README.md
+++ b/README.md
@@ -423,27 +423,22 @@ Nickname added: "Grace Hopper (a.k.a. The Admiral a.k.a. Amazing Grace)"
 
 #### Setting a default location
 
-You can set a default location in`friends`. Thereafter, whenever an activity is added and does not mention a location, the activity will be automatically 'tagged' with the default location.
-
-To set a default location, use the phrase `to location` (eg `moved to Paris`), when adding an activity:
+When an activity includes the phrase to \_LOCATION\_ (e.g., Took a plane to \_Paris\_), all future activities that have no explicit location will be associated with that location:
 
 ```bash
-$ friends add activity Moved to Paris
-Activity added: "2018-01-04: Moved to Paris”
-Default location added: “Paris”
-```
-
-Then, when subsequent activities are added without an explicit location, friends will automatically tag the activity with the default location:
-
-```bash
-$ friends add activity Went to a cafe with George
-Activity added: "2018-01-04: Went to a cafe with George
+$ friends add activity Took a plane to _Paris_
+Activity added: "2020-01-04: Took a plane to Paris"
+Default location set to: "Paris"
+$ friends add activity Ate lunch at a charming café
+Activity added: "2020-01-04: Ate lunch at a charming café"
+$ friends add activity Left the city to go to _Chamonix_
+Activity added: "2020-01-04: Left the city to go to Chamonix"
 ```
 
 ```bash
-$ friends list activities --in “Paris”
-2018-01-04: Went to a cafe with George
-2018-01-04: Moved to Paris
+$ friends list activities --in Paris
+2019-01-04: Ate lunch at a charming café
+2019-01-04: Took a plane to Paris
 ```
 
 #### `clean`

--- a/friends.md
+++ b/friends.md
@@ -1,5 +1,5 @@
 ### Activities:
-- 2018-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2018-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
 - 2018-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2017-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2017-11-15: Talked to **George Washington Carver** on the phone for an hour.

--- a/friends.md
+++ b/friends.md
@@ -1,5 +1,5 @@
 ### Activities:
-- 2018-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2018-11-01: **Grace Hopper** and I went to Marie's Diner. George had to cancel at the last minute. @food
 - 2018-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2017-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2017-11-15: Talked to **George Washington Carver** on the phone for an hour.
@@ -15,5 +15,4 @@
 
 ### Locations:
 - Atlantis
-- Marie's Diner
 - Paris

--- a/friends.md
+++ b/friends.md
@@ -1,5 +1,5 @@
 ### Activities:
-- 2018-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
+- 2018-11-01: **Grace Hopper** and I went to _Martha's Vineyard_. George had to cancel at the last minute.
 - 2018-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2017-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2017-11-15: Talked to **George Washington Carver** on the phone for an hour.
@@ -15,5 +15,5 @@
 
 ### Locations:
 - Atlantis
-- Marie's Diner
+- Martha's Vineyard
 - Paris

--- a/friends.md
+++ b/friends.md
@@ -1,5 +1,5 @@
 ### Activities:
-- 2018-11-01: **Grace Hopper** and I went to Marie's Diner. George had to cancel at the last minute. @food
+- 2018-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
 - 2018-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2017-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2017-11-15: Talked to **George Washington Carver** on the phone for an hour.
@@ -15,4 +15,5 @@
 
 ### Locations:
 - Atlantis
+- Marie's Diner
 - Paris

--- a/lib/friends/event.rb
+++ b/lib/friends/event.rb
@@ -139,7 +139,7 @@ module Friends
     end
 
     def default_location
-      @description[/(?<=to _)\w[^_]*(?=_)/]
+      @default_location ||= @description[/(?<=to _)\w[^_]*(?=_)/]
     end
 
     # @param friend [Friend] the friend to test

--- a/lib/friends/event.rb
+++ b/lib/friends/event.rb
@@ -138,8 +138,8 @@ module Friends
       location_in_description?(location) || location_is_implicit?(location)
     end
 
-    def moved_to_location
-      @description[/(?<=[mM]oved to _)\w[^_]*(?=_)/]
+    def default_location
+      @description[/(?<=to _)\w[^_]*(?=_)/]
     end
 
     # @param friend [Friend] the friend to test

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -110,8 +110,8 @@ module Friends
         @activities.unshift(activity)
 
         @output << "Activity added: \"#{activity}\""
-        if is_activity_setting_default_location?(activity)
-        	@output << "Default location set to: \"#{activity.default_location}\"" 
+        if activity_sets_default_location?(activity)
+          @output << "Default location set to: \"#{activity.default_location}\""
         end
       end
     end
@@ -784,9 +784,9 @@ module Friends
     # Check if an activity is setting a specific default location for the first time.
     # @param expected [Activity] the activity to check
     # @return [Boolean]
-    def is_activity_setting_default_location?(activity)
-    	previous_activities = @activities - [activity]
-    	activity.default_location && previous_activities.none? { |activity| activity.default_location }
+    def activity_sets_default_location?(activity)
+      previous_activities = @activities - [activity]
+      activity.default_location && previous_activities.none?(&:default_location)
     end
   end
 end

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -110,6 +110,7 @@ module Friends
         @activities.unshift(activity)
 
         @output << "Activity added: \"#{activity}\""
+        @output << "Default location set to: \"#{activity.default_location}\"" if activity.default_location && (@activities - [activity]).none? { |activity| activity.default_location }  
       end
     end
 

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -786,7 +786,7 @@ module Friends
 
       str = "Default location"
       if activity != @activities.first
-        str += " from #{earliest_default_activity_date(activity, existing_activities)} to"
+        str += " from #{earliest_consecutive_default_location_activity_date(activity, existing_activities)} to"
         str += " #{next_activity_date_with_different_default_location(activity, existing_activities) || 'present'}"
       end
 
@@ -803,10 +803,17 @@ module Friends
       end
     end
 
-    def earliest_default_activity_date(activity, existing_activities)
-      last_default_location_activity = existing_activities.select { |a| a.default_location && (a.default_location == activity.default_location) && (a.date < activity.date) }.first
-      if last_default_location_activity
-        return last_default_location_activity.date
+    def earliest_consecutive_default_location_activity_date(activity, existing_activities)
+      # binding.pry
+      earlier_default_location_activities = existing_activities.select { |a| a.default_location && (a.date < activity.date) }
+      consecutively_earliest_activity_with_same_default_location = nil
+      earlier_default_location_activities.each do |act|
+        break if act.default_location != activity.default_location
+        consecutively_earliest_activity_with_same_default_location = act if act.default_location == activity.default_location
+      end
+      # last_default_location_activity = existing_activities.select { |a| a.default_location && (a.default_location == activity.default_location) && (a.date < activity.date) }.first
+      if consecutively_earliest_activity_with_same_default_location
+        return consecutively_earliest_activity_with_same_default_location.date
       else
         return activity.date
       end

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -108,7 +108,7 @@ module Friends
         activity.highlight_description(introvert: self)
 
         @output << "Activity added: \"#{activity}\""
-        
+
         @output << default_location_output(activity) if activity.default_location
 
         @activities.unshift(activity)
@@ -662,7 +662,7 @@ module Friends
 
     def set_implicit_locations!
       implicit_location = nil
-      #reverse_each here moves through the activities in chronological order
+      # reverse_each here moves through the activities in chronological order
       @activities.reverse_each do |activity|
         implicit_location = activity.default_location if activity.default_location
         activity.implicit_location = implicit_location if activity.description_location_names.empty?
@@ -688,7 +688,7 @@ module Friends
         # Parse the line and update the parsing state.
         state = parse_line!(line, line_num: line_num, state: state)
       end
-      #sort the activities from earliest to latest, in case friends.md has been corrupted
+      # sort the activities from earliest to latest, in case friends.md has been corrupted
       @activities = stable_sort(@activities)
 
       set_implicit_locations!
@@ -725,7 +725,7 @@ module Friends
 
       begin
         instance_variable_get("@#{stage.id}") << stage.klass.deserialize(line)
-      rescue => ex
+      rescue StandardError => ex
         bad_line(ex, line_num)
       end
 
@@ -788,32 +788,31 @@ module Friends
     # @return [String] specifying default location and its time range
     def default_location_output(activity)
       str = "Default location"
-      
+
       earlier_activities, later_activities = @activities.partition { |a| a.date <= activity.date }
-      
+
       earlier_activity_with_default_location = activity
-      
+
       earlier_activities.each do |a|
-        
         next unless a.default_location
-        
+
         break unless a.default_location == activity.default_location
-        
+
         earlier_activity_with_default_location = a
       end
-      
-      if !later_activities.empty?
+
+      unless later_activities.empty?
         str += " from #{Paint[earlier_activity_with_default_location.date, :bold]}"
-        
-        later_activity = later_activities.find do |a|    
+
+        later_activity = later_activities.find do |a|
           a.default_location && a.default_location != activity.default_location
         end
-        
-        str += " to #{Paint[later_activity&.date || 'present', :bold]}"        
+
+        str += " to #{Paint[(later_activity.date if later_activity) || 'present', :bold]}"
       end
 
       str += " already" if earlier_activity_with_default_location != activity
-      
+
       "#{str} set to: \"#{activity.default_location}\""
     end
   end

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -110,7 +110,9 @@ module Friends
         @activities.unshift(activity)
 
         @output << "Activity added: \"#{activity}\""
-        @output << "Default location set to: \"#{activity.default_location}\"" if activity.default_location && (@activities - [activity]).none? { |activity| activity.default_location }  
+        if is_activity_setting_default_location?(activity)
+        	@output << "Default location set to: \"#{activity.default_location}\"" 
+        end
       end
     end
 
@@ -777,6 +779,14 @@ module Friends
     # @raise [FriendsError] with a constructed message
     def bad_line(expected, line_num)
       raise FriendsError, "Expected \"#{expected}\" on line #{line_num}"
+    end
+
+    # Check if an activity is setting a specific default location for the first time.
+    # @param expected [Activity] the activity to check
+    # @return [Boolean]
+    def is_activity_setting_default_location?(activity)
+    	previous_activities = @activities - [activity]
+    	activity.default_location && previous_activities.none? { |activity| activity.default_location }
     end
   end
 end

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -781,11 +781,19 @@ module Friends
     end
 
     def decide_default_location_output(activity)
+      @activities = stable_sort(@activities)
+      existing_activities = @activities - [activity]
       str = "Default location "
-      previous_activities = @activities - [activity]
-      
-      if last_default_location_same_as_current_default_location?(activity, previous_activities)
-        str += "already "
+
+
+      if @activities.first == activity
+        if last_default_location_same_as_current_default_location?(activity, existing_activities)
+          str += "already "
+        end
+      else
+        if existing_activities.none?(&:default_location)
+          str += "from #{activity.date} to present "
+        end
       end
 
       str += "set to: \"#{activity.default_location}\""
@@ -793,18 +801,18 @@ module Friends
       @output << str
     end
 
-    def last_default_location_same_as_current_default_location?(activity, previous_activities)
-      last_default_location_activity = previous_activities.select {|a| a.default_location }.first
+    def last_default_location_same_as_current_default_location?(activity, existing_activities)
+      last_default_location_activity = existing_activities.select {|a| a.default_location }.first
       if last_default_location_activity
         last_default_location_activity.default_location == activity.default_location
       end
     end
-    
+
     # Check if an activity is setting a specific default location for the first time.
     # @param expected [Activity] the activity to check
     # @return [Boolean]
-    # def no_previous_default_locations?(previous_activities)
-    #   previous_activities.none?(&:default_location)
+    # def no_previous_default_locations?(existing_activities)
+    #   existing_activities.none?(&:default_location)
     # end
 
   end

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -784,12 +784,14 @@ module Friends
       @activities = stable_sort(@activities)
       existing_activities = @activities - [activity]
 
-      str = "Default location "
+      str = "Default location"
       if activity != @activities.first
-        str += "from #{earliest_default_activity_date(activity, existing_activities)} to present "
+        str += " from #{earliest_default_activity_date(activity, existing_activities)} to"
+        str += " #{next_activity_date_with_different_default_location(activity, existing_activities) || 'present'}"
       end
-      str += "already " if last_default_location_same_as_added_default_location?(activity, existing_activities)
-      str += "set to: \"#{activity.default_location}\""
+
+      str += " already" if last_default_location_same_as_added_default_location?(activity, existing_activities)
+      str += " set to: \"#{activity.default_location}\""
 
       @output << str
     end
@@ -807,6 +809,15 @@ module Friends
         return last_default_location_activity.date
       else
         return activity.date
+      end
+    end
+
+    def next_activity_date_with_different_default_location(activity, existing_activities)
+      next_default_location_activity = existing_activities.select {|a| a.default_location && (a.date > activity.date) }.first
+      if next_default_location_activity
+        return next_default_location_activity.date
+      else
+        return nil
       end
     end
 

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -804,7 +804,7 @@ module Friends
     end
 
     def earliest_default_activity_date(activity, existing_activities)
-      last_default_location_activity = existing_activities.select { |a| a.default_location && (a.date < activity.date) }.first
+      last_default_location_activity = existing_activities.select { |a| a.default_location && (a.default_location == activity.default_location) && (a.date < activity.date) }.first
       if last_default_location_activity
         return last_default_location_activity.date
       else
@@ -814,7 +814,7 @@ module Friends
 
     def next_activity_date_with_different_default_location(activity, existing_activities)
       next_default_location_activity = existing_activities.select { |a| a.default_location && (a.date > activity.date) }.first
-      if next_default_location_activity
+      if next_default_location_activity && (next_default_location_activity.default_location != activity.default_location)
         return next_default_location_activity.date
       else
         return nil

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -110,7 +110,7 @@ module Friends
         @activities.unshift(activity)
 
         @output << "Activity added: \"#{activity}\""
-        
+
         decide_default_location_output(activity) if activity.default_location
       end
     end
@@ -797,14 +797,14 @@ module Friends
     end
 
     def last_default_location_same_as_added_default_location?(activity, existing_activities)
-      last_default_location_activity = existing_activities.select {|a| a.default_location && (a.date < activity.date) }.first
+      last_default_location_activity = existing_activities.select { |a| a.default_location && (a.date < activity.date) }.first
       if last_default_location_activity
         last_default_location_activity.default_location == activity.default_location
       end
     end
 
     def earliest_default_activity_date(activity, existing_activities)
-      last_default_location_activity = existing_activities.select {|a| a.default_location && (a.date < activity.date) }.first
+      last_default_location_activity = existing_activities.select { |a| a.default_location && (a.date < activity.date) }.first
       if last_default_location_activity
         return last_default_location_activity.date
       else
@@ -813,7 +813,7 @@ module Friends
     end
 
     def next_activity_date_with_different_default_location(activity, existing_activities)
-      next_default_location_activity = existing_activities.select {|a| a.default_location && (a.date > activity.date) }.first
+      next_default_location_activity = existing_activities.select { |a| a.default_location && (a.date > activity.date) }.first
       if next_default_location_activity
         return next_default_location_activity.date
       else
@@ -838,6 +838,5 @@ module Friends
     # def no_previous_default_locations?(existing_activities)
     #   existing_activities.none?(&:default_location)
     # end
-
   end
 end

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -781,7 +781,6 @@ module Friends
       raise FriendsError, "Expected \"#{expected}\" on line #{line_num}"
     end
 
-    # Return a string specifying what default location was set and its time range
     # @param [Activity] the activity that was added by the user
     # @return [String] specifying default location and its time range
     def default_location_output(activity)

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -811,7 +811,6 @@ module Friends
         break if act.default_location != activity.default_location
         consecutively_earliest_activity_with_same_default_location = act if act.default_location == activity.default_location
       end
-      # last_default_location_activity = existing_activities.select { |a| a.default_location && (a.default_location == activity.default_location) && (a.date < activity.date) }.first
       if consecutively_earliest_activity_with_same_default_location
         return consecutively_earliest_activity_with_same_default_location.date
       else
@@ -827,23 +826,5 @@ module Friends
         return nil
       end
     end
-
-    # def is_default_location_before_added_same?(activity, existing_activities)
-    #   last_default_location_activity = existing_activities.select {|a| a.default_location && (a.date < activity.date) }.first
-    #   if last_default_location_activity
-    #     last_default_location_activity.default_location == activity.default_location
-    #   end
-    # end
-
-    # def get_last_default_location_activity(activity, existing_activities)
-    #   last_default_location_activity = existing_activities.select {|a| a.default_location && (a.date < activity.date) }.first
-    # end
-
-    # Check if an activity is setting a specific default location for the first time.
-    # @param expected [Activity] the activity to check
-    # @return [Boolean]
-    # def no_previous_default_locations?(existing_activities)
-    #   existing_activities.none?(&:default_location)
-    # end
   end
 end

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -110,8 +110,15 @@ module Friends
         @activities.unshift(activity)
 
         @output << "Activity added: \"#{activity}\""
-        if activity_sets_default_location?(activity)
-          @output << "Default location set to: \"#{activity.default_location}\""
+        
+        if activity_sets_default_location_for_the_first_time?(activity)
+          @output << "Default location set to: \"#{activity.default_location}\"" 
+        end
+
+        previous_activities = @activities - [activity]
+        current_default_location = activity.default_location 
+        if ( previous_activities.any? { |a| a.default_location == current_default_location } )
+          @output << "Default location already set to: \"#{activity.default_location}\""
         end
       end
     end
@@ -784,7 +791,7 @@ module Friends
     # Check if an activity is setting a specific default location for the first time.
     # @param expected [Activity] the activity to check
     # @return [Boolean]
-    def activity_sets_default_location?(activity)
+    def activity_sets_default_location_for_the_first_time?(activity)
       previous_activities = @activities - [activity]
       activity.default_location && previous_activities.none?(&:default_location)
     end

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -111,15 +111,7 @@ module Friends
 
         @output << "Activity added: \"#{activity}\""
         
-        if activity_sets_default_location_for_the_first_time?(activity)
-          @output << "Default location set to: \"#{activity.default_location}\"" 
-        end
-
-        previous_activities = @activities - [activity]
-        current_default_location = activity.default_location 
-        if ( previous_activities.any? { |a| a.default_location == current_default_location } )
-          @output << "Default location already set to: \"#{activity.default_location}\""
-        end
+        decide_default_location_output(activity) if activity.default_location
       end
     end
 
@@ -788,12 +780,28 @@ module Friends
       raise FriendsError, "Expected \"#{expected}\" on line #{line_num}"
     end
 
+    def decide_default_location_output(activity)
+
+      previous_activities = @activities - [activity]
+      if activity_sets_default_location_for_the_first_time?(previous_activities)
+        @output << "Default location set to: \"#{activity.default_location}\""
+      end 
+      if activity_sets_default_location_immediately_again?(activity, previous_activities)
+        @output << "Default location already set to: \"#{activity.default_location}\""
+      end
+    end
+
+
     # Check if an activity is setting a specific default location for the first time.
     # @param expected [Activity] the activity to check
     # @return [Boolean]
-    def activity_sets_default_location_for_the_first_time?(activity)
-      previous_activities = @activities - [activity]
-      activity.default_location && previous_activities.none?(&:default_location)
+    def activity_sets_default_location_for_the_first_time?(previous_activities)
+      previous_activities.none?(&:default_location)
+    end
+
+    def activity_sets_default_location_immediately_again?(activity, previous_activities)
+      current_default_location = activity.default_location 
+      previous_activities.any? { |a| a.default_location == current_default_location }
     end
   end
 end

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -725,7 +725,7 @@ module Friends
 
       begin
         instance_variable_get("@#{stage.id}") << stage.klass.deserialize(line)
-      rescue => ex # rubocop:disable Style/RescueStandardError
+      rescue => ex
         bad_line(ex, line_num)
       end
 

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -662,6 +662,7 @@ module Friends
 
     def set_implicit_locations!
       implicit_location = nil
+      #reverse_each here moves through the activities in chronological order
       @activities.reverse_each do |activity|
         implicit_location = activity.default_location if activity.default_location
         activity.implicit_location = implicit_location if activity.description_location_names.empty?

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -661,7 +661,7 @@ module Friends
     def set_implicit_locations!
       implicit_location = nil
       @activities.reverse_each do |activity|
-        implicit_location = activity.moved_to_location if activity.moved_to_location
+        implicit_location = activity.default_location if activity.default_location
         activity.implicit_location = implicit_location if activity.description_location_names.empty?
       end
     end

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -781,41 +781,31 @@ module Friends
     end
 
     def decide_default_location_output(activity)
-
+      str = "Default location "
       previous_activities = @activities - [activity]
-      if activity_sets_default_location_for_the_first_time?(previous_activities) || activity_sets_default_location_again_after_another_default_location?(activity, previous_activities)
-        @output << "Default location set to: \"#{activity.default_location}\""
-      end 
-      if activity_sets_default_location_immediately_again?(activity, previous_activities)
-        @output << "Default location already set to: \"#{activity.default_location}\""
+      
+      if last_default_location_same_as_current_default_location?(activity, previous_activities)
+        str += "already "
       end
+
+      str += "set to: \"#{activity.default_location}\""
+
+      @output << str
     end
 
-
+    def last_default_location_same_as_current_default_location?(activity, previous_activities)
+      last_default_location_activity = previous_activities.select {|a| a.default_location }.first
+      if last_default_location_activity
+        last_default_location_activity.default_location == activity.default_location
+      end
+    end
+    
     # Check if an activity is setting a specific default location for the first time.
     # @param expected [Activity] the activity to check
     # @return [Boolean]
-    def activity_sets_default_location_for_the_first_time?(previous_activities)
-      previous_activities.none?(&:default_location)
-    end
+    # def no_previous_default_locations?(previous_activities)
+    #   previous_activities.none?(&:default_location)
+    # end
 
-    def activity_sets_default_location_immediately_again?(activity, previous_activities)
-      current_default_location = activity.default_location 
-      previous_activities.any? { |a| a.default_location == current_default_location }
-    end
-
-    def activity_sets_default_location_again_after_another_default_location?(activity, previous_activities)
-      var = false
-      previous_activity_with_current_default_location = nil
-      previous_activities.each {|a| previous_activity_with_current_default_location = a if a.default_location == activity.default_location}
-      if previous_activity_with_current_default_location
-        previous_activities.each do |act|
-          if act.default_location && act.default_location != activity.default_location && act.date > previous_activity_with_current_default_location.date
-            var = true
-          end
-        end
-      end
-      return var
-    end
   end
 end

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -111,7 +111,7 @@ module Friends
 
         @output << "Activity added: \"#{activity}\""
 
-        decide_default_location_output(activity) if activity.default_location
+        @output << default_location_output(activity) if activity.default_location
       end
     end
 
@@ -781,7 +781,10 @@ module Friends
       raise FriendsError, "Expected \"#{expected}\" on line #{line_num}"
     end
 
-    def decide_default_location_output(activity)
+    # Return a string specifying what default location was set and its time range
+    # @param [Activity] the activity that was added by the user
+    # @return [String] specifying default location and its time range
+    def default_location_output(activity)
       @activities = stable_sort(@activities)
       existing_activities = @activities - [activity]
 

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -688,7 +688,7 @@ module Friends
         # Parse the line and update the parsing state.
         state = parse_line!(line, line_num: line_num, state: state)
       end
-
+      #sort the activities from earliest to latest, in case friends.md has been corrupted
       @activities = stable_sort(@activities)
 
       set_implicit_locations!
@@ -787,9 +787,6 @@ module Friends
     # @param [Activity] the activity that was added by the user
     # @return [String] specifying default location and its time range
     def default_location_output(activity)
-      #sort the activities from earliest to latest, in case friends.md has been corrupted
-      @activities = stable_sort(@activities)
-      
       str = "Default location"
       
       earlier_activities, later_activities = @activities.partition { |a| a.date <= activity.date }

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -820,9 +820,9 @@ module Friends
     end
 
     def next_activity_date_with_different_default_location(activity, existing_activities)
-      next_default_location_activity = existing_activities.select { |a| a.default_location && (a.date > activity.date) }.first
-      if next_default_location_activity && (next_default_location_activity.default_location != activity.default_location)
-        return next_default_location_activity.date
+      next_activity_with_different_default_location = existing_activities.select { |a| a.default_location && (a.date > activity.date) && a.default_location != activity.default_location }.first
+      if next_activity_with_different_default_location
+        return next_activity_with_different_default_location.date
       else
         return nil
       end

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -793,6 +793,8 @@ module Friends
       else
         if existing_activities.none?(&:default_location)
           str += "from #{activity.date} to present "
+        elsif is_default_location_before_added_same?(activity, existing_activities) 
+          str += "from #{get_last_default_location_activity(activity, existing_activities).date} to present already "    
         end
       end
 
@@ -806,6 +808,17 @@ module Friends
       if last_default_location_activity
         last_default_location_activity.default_location == activity.default_location
       end
+    end
+
+    def is_default_location_before_added_same?(activity, existing_activities)
+      last_default_location_activity = existing_activities.select {|a| a.default_location && (a.date < activity.date) }.first
+      if last_default_location_activity
+        last_default_location_activity.default_location == activity.default_location
+      end
+    end
+
+    def get_last_default_location_activity(activity, existing_activities)
+      last_default_location_activity = existing_activities.select {|a| a.default_location && (a.date < activity.date) }.first
     end
 
     # Check if an activity is setting a specific default location for the first time.

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -688,6 +688,9 @@ module Friends
         # Parse the line and update the parsing state.
         state = parse_line!(line, line_num: line_num, state: state)
       end
+
+      @activities = stable_sort(@activities)
+
       set_implicit_locations!
 
       set_n_activities!(:friend)

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -783,7 +783,7 @@ module Friends
     def decide_default_location_output(activity)
 
       previous_activities = @activities - [activity]
-      if activity_sets_default_location_for_the_first_time?(previous_activities)
+      if activity_sets_default_location_for_the_first_time?(previous_activities) || activity_sets_default_location_again_after_another_default_location?(activity, previous_activities)
         @output << "Default location set to: \"#{activity.default_location}\""
       end 
       if activity_sets_default_location_immediately_again?(activity, previous_activities)
@@ -802,6 +802,20 @@ module Friends
     def activity_sets_default_location_immediately_again?(activity, previous_activities)
       current_default_location = activity.default_location 
       previous_activities.any? { |a| a.default_location == current_default_location }
+    end
+
+    def activity_sets_default_location_again_after_another_default_location?(activity, previous_activities)
+      var = false
+      previous_activity_with_current_default_location = nil
+      previous_activities.each {|a| previous_activity_with_current_default_location = a if a.default_location == activity.default_location}
+      if previous_activity_with_current_default_location
+        previous_activities.each do |act|
+          if act.default_location && act.default_location != activity.default_location && act.date > previous_activity_with_current_default_location.date
+            var = true
+          end
+        end
+      end
+      return var
     end
   end
 end

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -783,43 +783,43 @@ module Friends
     def decide_default_location_output(activity)
       @activities = stable_sort(@activities)
       existing_activities = @activities - [activity]
+
       str = "Default location "
-
-
-      if @activities.first == activity
-        if last_default_location_same_as_current_default_location?(activity, existing_activities)
-          str += "already "
-        end
-      else
-        if existing_activities.none?(&:default_location)
-          str += "from #{activity.date} to present "
-        elsif is_default_location_before_added_same?(activity, existing_activities) 
-          str += "from #{get_last_default_location_activity(activity, existing_activities).date} to present already "    
-        end
+      if activity != @activities.first
+        str += "from #{earliest_default_activity_date(activity, existing_activities)} to present "
       end
-
+      str += "already " if last_default_location_same_as_added_default_location?(activity, existing_activities)
       str += "set to: \"#{activity.default_location}\""
 
       @output << str
     end
 
-    def last_default_location_same_as_current_default_location?(activity, existing_activities)
-      last_default_location_activity = existing_activities.select {|a| a.default_location }.first
-      if last_default_location_activity
-        last_default_location_activity.default_location == activity.default_location
-      end
-    end
-
-    def is_default_location_before_added_same?(activity, existing_activities)
+    def last_default_location_same_as_added_default_location?(activity, existing_activities)
       last_default_location_activity = existing_activities.select {|a| a.default_location && (a.date < activity.date) }.first
       if last_default_location_activity
         last_default_location_activity.default_location == activity.default_location
       end
     end
 
-    def get_last_default_location_activity(activity, existing_activities)
+    def earliest_default_activity_date(activity, existing_activities)
       last_default_location_activity = existing_activities.select {|a| a.default_location && (a.date < activity.date) }.first
+      if last_default_location_activity
+        return last_default_location_activity.date
+      else
+        return activity.date
+      end
     end
+
+    # def is_default_location_before_added_same?(activity, existing_activities)
+    #   last_default_location_activity = existing_activities.select {|a| a.default_location && (a.date < activity.date) }.first
+    #   if last_default_location_activity
+    #     last_default_location_activity.default_location == activity.default_location
+    #   end
+    # end
+
+    # def get_last_default_location_activity(activity, existing_activities)
+    #   last_default_location_activity = existing_activities.select {|a| a.default_location && (a.date < activity.date) }.first
+    # end
 
     # Check if an activity is setting a specific default location for the first time.
     # @param expected [Activity] the activity to check

--- a/test/add_event_helper.rb
+++ b/test/add_event_helper.rb
@@ -449,15 +449,15 @@ FILE
     end
 
     describe "when description contains both names and locations" do
-      let(:description) { "Grace and I went to Atlantis and then Paris for lunch with George." }
+      let(:description) { "Grace and I visited Atlantis and then Paris for lunch with George." }
 
       it do
-        line_added "- #{date}: **Grace Hopper** and I went to _Atlantis_ and then _Paris_ for "\
+        line_added "- #{date}: **Grace Hopper** and I visited _Atlantis_ and then _Paris_ for "\
                    "lunch with **George Washington Carver**."
       end
       if test_stdout
         it do
-          stdout_only "#{capitalized_event} added: \"#{date}: Grace Hopper and I went to "\
+          stdout_only "#{capitalized_event} added: \"#{date}: Grace Hopper and I visited "\
                       "Atlantis and then Paris for lunch with George Washington Carver.\""
         end
       end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -323,7 +323,7 @@ FILE
 FILE
         end
 
-        it  "uses the sorted order for determining output" do
+        it "uses the sorted order for determining output" do
           output = 'Default location from 2009-01-01 to 2018-01-01 set to: "Paris"'
           assert_default_location_output(output)
         end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -70,23 +70,27 @@ FILE
       describe "when there is no preceding default location" do
         let(:preceding_activity) { "2016-01-01: Went to the library." }
 
-        it 'prints "Default location set to" output message' do
-          assert_default_location_output('Default location set to: "Paris"')
+        it "prints 'Default location set to [LOCATION]'" do
+          output = 'Default location set to: "Paris"'
+          assert_default_location_output(output)
         end
       end
 
       describe "when preceding default location is different" do
         let(:preceding_activity) { "2016-01-01: Moved to _Berlin_." }
-        it 'prints "Default location set to" output message' do
-          assert_default_location_output('Default location set to: "Paris"')
+
+        it "prints 'Default location set to [LOCATION]'" do
+          output = 'Default location set to: "Paris"'
+          assert_default_location_output(output)
         end
       end
 
       describe "when preceding default location is the same" do
         let(:preceding_activity) { "2016-01-01: Flew to _Paris_." }
 
-        it 'prints "Default location already set to" output message' do
-          assert_default_location_output('Default location already set to: "Paris"')
+        it "prints 'Default location already set to [LOCATION]'" do
+          output = 'Default location already set to: "Paris"'
+          assert_default_location_output(output)
         end
       end
     end
@@ -113,24 +117,28 @@ FILE
         describe "when there is no preceding default location" do
           let(:preceding_activity) { "1999-01-01: Visited a library" }
 
-          it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
-            assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
+          it "prints 'Default location from [ADDED ACTIVITY DATE] to present set to [LOCATION]'" do
+            message = 'Default location from 2009-01-01 to present set to: "Paris"'
+            assert_default_location_output(message)
           end
         end
 
         describe "when preceding default location is different" do
           let(:preceding_activity) { "1999-01-01: Went to _Berlin_" }
 
-          it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
-            assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
+          it "prints 'Default location from [ADDED ACTIVITY DATE] to present set to [LOCATION]'" do
+            output = 'Default location from 2009-01-01 to present set to: "Paris"'
+            assert_default_location_output(output)
           end
         end
 
         describe "when preceding default location is same" do
           let(:preceding_activity) { "1999-01-01: Went to _Paris_" }
 
-          it 'prints "Default location from [PRECEDING DEFAULT LOCATION ACTIVITY DATE] to present already set to" output message' do
-            assert_default_location_output('Default location from 1999-01-01 to present already set to: "Paris"')
+          it  "prints 'Default location from [PRECEDING DEFAULT LOCATION ACTIVITY DATE] to " \
+              "present already set to [LOCATION]'" do
+            output = 'Default location from 1999-01-01 to present already set to: "Paris"'
+            assert_default_location_output(output)
           end
         end
 
@@ -150,8 +158,11 @@ FILE
 FILE
           end
 
-          it 'prints "Default location from [EARLIEST CONSECUTIVE DEFAULT LOCATION ACTIVITY DATE] to present already set to" output message' do
-            assert_default_location_output('Default location from 1989-01-01 to present already set to: "Paris"')
+          it  "prints 'Default location from " \
+              "[EARLIEST CONSECUTIVE DEFAULT LOCATION ACTIVITY DATE] to " \
+              "present already set to [LOCATION]'" do
+            output = 'Default location from 1989-01-01 to present already set to: "Paris"'
+            assert_default_location_output(output)
           end
         end
 
@@ -172,8 +183,11 @@ FILE
 FILE
           end
 
-          it 'prints "Default location from [EARLIEST CONSECUTIVE DEFAULT LOCATION ACTIVITY DATE] to present already set to" output message' do
-            assert_default_location_output('Default location from 1999-01-01 to present already set to: "Paris"')
+          it  "prints 'Default location from " \
+              "[EARLIEST CONSECUTIVE DEFAULT LOCATION ACTIVITY DATE] to " \
+              "present already set to [LOCATION]'" do
+            output = 'Default location from 1999-01-01 to present already set to: "Paris"'
+            assert_default_location_output(output)
           end
         end
       end
@@ -184,16 +198,19 @@ FILE
         describe "when following default location is the same" do
           let(:following_activity) { "2019-01-01: Went to _Paris_" }
 
-          it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
-            assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
+          it "prints 'Default location from [ADDED ACTIVITY DATE] to present set to [LOCATION]'" do
+            output = 'Default location from 2009-01-01 to present set to: "Paris"'
+            assert_default_location_output(output)
           end
         end
 
         describe "when following default location is different" do
           let(:following_activity) { "2019-01-01: Went to _Berlin_" }
 
-          it 'prints "Default location from [ADDED ACTIVITY DATE] to [NEXT DIFFERENT DEFAULT LOCATION ACIVITY DATE] set to" output message' do
-            assert_default_location_output('Default location from 2009-01-01 to 2019-01-01 set to: "Paris"')
+          it  "prints 'Default location from [ADDED ACTIVITY DATE] to " \
+              "[NEXT DIFFERENT DEFAULT LOCATION ACIVITY DATE] set to [LOCATION]'" do
+            output = 'Default location from 2009-01-01 to 2019-01-01 set to: "Paris"'
+            assert_default_location_output(output)
           end
         end
 
@@ -212,8 +229,9 @@ FILE
 FILE
           end
 
-          it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
-            assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
+          it "prints 'Default location from [ADDED ACTIVITY DATE] to present set to [LOCATION]'" do
+            output = 'Default location from 2009-01-01 to present set to: "Paris"'
+            assert_default_location_output(output)
           end
         end
 
@@ -233,8 +251,10 @@ FILE
 FILE
           end
 
-          it 'prints "Default location from [ADDED ACTIVITY DATE] to [NEXT DIFFERENT DEFAULT LOCATION ACIVITY DATE] set to" output message' do
-            assert_default_location_output('Default location from 2009-01-01 to 2018-01-01 set to: "Paris"')
+          it  "prints 'Default location from [ADDED ACTIVITY DATE] to " \
+              "[NEXT DIFFERENT DEFAULT LOCATION ACIVITY DATE] set to [LOCATION]'" do
+            output = 'Default location from 2009-01-01 to 2018-01-01 set to: "Paris"'
+            assert_default_location_output(output)
           end
         end
       end
@@ -245,16 +265,21 @@ FILE
         describe "when following default location is the same" do
           let(:following_activity) { "2019-01-01: Relocated to _Paris_" }
 
-          it 'prints "Default location from [PRECEDING ACTIVITY DATE] to present already set to" output message' do
-            assert_default_location_output('Default location from 1999-01-01 to present already set to: "Paris"')
+          it  "prints 'Default location from " \
+              "[PRECEDING ACTIVITY DATE] to present already set to [LOCATION]'" do
+            output = 'Default location from 1999-01-01 to present already set to: "Paris"'
+            assert_default_location_output(output)
           end
         end
 
         describe "when following default location is different" do
           let(:following_activity) { "2019-01-01: Relocated to _Berlin_" }
 
-          it 'prints "Default location from [PRECEDING ACTIVITY DATE] to [FOLLOWING ACTIVITY DATE] set to" output message' do
-            assert_default_location_output('Default location from 1999-01-01 to 2019-01-01 already set to: "Paris"')
+          it  "prints 'Default location from " \
+              "[PRECEDING ACTIVITY DATE] to " \
+              "[FOLLOWING ACTIVITY DATE] set to [LOCATION]'" do
+            output = 'Default location from 1999-01-01 to 2019-01-01 already set to: "Paris"'
+            assert_default_location_output(output)
           end
         end
       end
@@ -265,16 +290,20 @@ FILE
         describe "when following default location is the same" do
           let(:following_activity) { "2019-01-01: Relocated to _Paris_" }
 
-          it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
-            assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
+          it "prints 'Default location from [ADDED ACTIVITY DATE] to present set to [LOCATION]'" do
+            output = 'Default location from 2009-01-01 to present set to: "Paris"'
+            assert_default_location_output(output)
           end
         end
 
         describe "when following default location is different" do
           let(:following_activity) { "2019-01-01: Relocated to _Berlin_" }
 
-          it 'prints "Default location from [ADDED ACTIVITY DATE] to [FOLLOWING ACTIVITY DATE] set to" output message' do
-            assert_default_location_output('Default location from 2009-01-01 to 2019-01-01 set to: "Paris"')
+          it  "prints 'Default location from " \
+              "[ADDED ACTIVITY DATE] to " \
+              "[FOLLOWING ACTIVITY DATE] set to [LOCATION]'" do
+            output = 'Default location from 2009-01-01 to 2019-01-01 set to: "Paris"'
+            assert_default_location_output(output)
           end
         end
       end
@@ -295,8 +324,10 @@ FILE
 FILE
         end
 
-        it 'prints "Default location from [ADDED ACTIVITY DATE] to [FOLLOWING ACTIVITY DATE] set to" output message' do
-          assert_default_location_output('Default location from 2009-01-01 to 2018-01-01 set to: "Paris"')
+        it  "prints 'Default location from " \
+            "[ADDED ACTIVITY DATE] to [FOLLOWING ACTIVITY DATE] set to [LOCATION]'" do
+          output = 'Default location from 2009-01-01 to 2018-01-01 set to: "Paris"'
+          assert_default_location_output(output)
         end
       end
     end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -97,7 +97,7 @@ FILE
       let(:content) do
   <<-FILE
 ### Activities:
-- #{proceeding_activity}
+- #{following_activity}
 - #{preceding_activity}
 
 ### Notes:
@@ -109,7 +109,7 @@ FILE
       end
 
       describe "when proceeding activities have no default location" do
-        let(:proceeding_activity) { "2019-01-01: Visted a cafe"}
+        let(:following_activity) { "2019-01-01: Visted a cafe"}
 
         describe "when preceding activities have no default location" do
           let(:preceding_activity) { "1999-01-01: Visted a library"}
@@ -190,7 +190,7 @@ FILE
         let(:preceding_activity) { "1999-01-01: Visted a cafe"}
 
         describe 'when single proceeding default location is the same' do
-          let(:proceeding_activity) { "2019-01-01: Went to _Paris_"}
+          let(:following_activity) { "2019-01-01: Went to _Paris_"}
 
           it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
@@ -199,7 +199,7 @@ FILE
         end
 
         describe 'when proceeding default location is different' do
-          let(:proceeding_activity) { "2019-01-01: Went to _Berlin_"}
+          let(:following_activity) { "2019-01-01: Went to _Berlin_"}
 
           it 'prints "Default location from [ADDED ACTIVITY DATE] to [DIFFERENT DEFAULT LOCATION ACTIVITY DATE] set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to 2019-01-01 set to: "Paris"')
@@ -256,7 +256,7 @@ FILE
         let(:preceding_activity) { "1999-01-01: Went to _Paris_"}
         
         describe 'when proceeding default location is the same' do
-          let(:proceeding_activity) { "2019-01-01: Relocated to _Paris_"}
+          let(:following_activity) { "2019-01-01: Relocated to _Paris_"}
 
           it 'prints "Default location from [PRECEDING ACTIVITY DATE] to present set to" output message' do
             assert_default_location_output('Default location from 1999-01-01 to present already set to: "Paris"')
@@ -265,7 +265,7 @@ FILE
         end  
 
         describe 'when proceeding default location is different' do
-          let(:proceeding_activity) { "2019-01-01: Relocated to _Berlin_"}
+          let(:following_activity) { "2019-01-01: Relocated to _Berlin_"}
 
           it 'prints "Default location from [PRECEDING ACTIVITY DATE] to [PROCEEDING ACTIVITY DATE] set to" output message' do
             assert_default_location_output('Default location from 1999-01-01 to 2019-01-01 already set to: "Paris"')
@@ -279,7 +279,7 @@ FILE
         let(:preceding_activity) { "1999-01-01: Went to _Berlin_"}
         
         describe 'when proceeding default location is the same' do
-          let(:proceeding_activity) { "2019-01-01: Relocated to _Paris_"}
+          let(:following_activity) { "2019-01-01: Relocated to _Paris_"}
 
           it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
@@ -288,7 +288,7 @@ FILE
         end  
 
         describe 'when proceeding default location is different' do
-          let(:proceeding_activity) { "2019-01-01: Relocated to _Berlin_"}
+          let(:following_activity) { "2019-01-01: Relocated to _Berlin_"}
 
           it 'prints "Default location from [ADDED ACTIVITY DATE] to [PROCEEDING ACTIVITY DATE] set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to 2019-01-01 set to: "Paris"')

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -67,8 +67,8 @@ FILE
 FILE
       end
 
-      describe "when a default location has never been set before" do
-        let(:preceding_activity) { "2016-01-01: Had dinner in _Berlin_." }
+      describe "when there is no preceding default location" do
+        let(:preceding_activity) { "2016-01-01: Went to the library." }
 
 
         it 'prints "Default location set to" output message' do
@@ -108,10 +108,10 @@ FILE
 FILE
       end
 
-      describe "when proceeding activities have no default location" do
+      describe "when there is no following default location" do
         let(:following_activity) { "2019-01-01: Visited a cafe"}
 
-        describe "when preceding activities have no default location" do
+        describe "when there is no preceding default location" do
           let(:preceding_activity) { "1999-01-01: Visited a library"}
 
           it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
@@ -132,14 +132,13 @@ FILE
         describe "when preceding default location is same" do
           let(:preceding_activity) { "1999-01-01: Went to _Paris_"}
 
-          it 'prints "Default location from [PRECEDING ACTIVITY DATE] to present already set to" output message' do
+          it 'prints "Default location from [PRECEDING DEFAULT LOCATION ACTIVITY DATE] to present already set to" output message' do
             assert_default_location_output('Default location from 1999-01-01 to present already set to: "Paris"')
           end
 
         end
 
         describe "when multiple preceding default locations are same and consecutive" do
-          let(:preceding_activity) { "1999-01-01: Went to _Paris_"}
           let(:content) do
             <<-FILE
 ### Activities:
@@ -186,10 +185,10 @@ FILE
 
       end
 
-      describe 'when preceding activities have no default locations' do
+      describe 'when there are no preceding default locations' do
         let(:preceding_activity) { "1999-01-01: Visited a cafe"}
 
-        describe 'when single proceeding default location is the same' do
+        describe 'when following default location is the same' do
           let(:following_activity) { "2019-01-01: Went to _Paris_"}
 
           it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
@@ -198,16 +197,16 @@ FILE
 
         end
 
-        describe 'when proceeding default location is different' do
+        describe 'when following default location is different' do
           let(:following_activity) { "2019-01-01: Went to _Berlin_"}
 
-          it 'prints "Default location from [ADDED ACTIVITY DATE] to [DIFFERENT DEFAULT LOCATION ACTIVITY DATE] set to" output message' do
+          it 'prints "Default location from [ADDED ACTIVITY DATE] to [NEXT DIFFERENT DEFAULT LOCATION ACIVITY DATE] set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to 2019-01-01 set to: "Paris"')
           end
 
         end
 
-        describe "when multiple proceeding default locations are the same and consecutive" do
+        describe "when multiple following default locations are the same and consecutive" do
           let(:content) do
             <<-FILE
 ### Activities:
@@ -228,7 +227,7 @@ FILE
 
         end
 
-        describe "when multiple proceeding default locations are the same but not consecutive" do
+        describe "when multiple following default locations are the same but not consecutive" do
           let(:content) do
             <<-FILE
 ### Activities:
@@ -255,19 +254,19 @@ FILE
       describe 'when preceding default location is the same' do
         let(:preceding_activity) { "1999-01-01: Went to _Paris_"}
         
-        describe 'when proceeding default location is the same' do
+        describe 'when following default location is the same' do
           let(:following_activity) { "2019-01-01: Relocated to _Paris_"}
 
-          it 'prints "Default location from [PRECEDING ACTIVITY DATE] to present set to" output message' do
+          it 'prints "Default location from [PRECEDING ACTIVITY DATE] to present already set to" output message' do
             assert_default_location_output('Default location from 1999-01-01 to present already set to: "Paris"')
           end
 
         end  
 
-        describe 'when proceeding default location is different' do
+        describe 'when following default location is different' do
           let(:following_activity) { "2019-01-01: Relocated to _Berlin_"}
 
-          it 'prints "Default location from [PRECEDING ACTIVITY DATE] to [PROCEEDING ACTIVITY DATE] set to" output message' do
+          it 'prints "Default location from [PRECEDING ACTIVITY DATE] to [FOLLOWING ACTIVITY DATE] set to" output message' do
             assert_default_location_output('Default location from 1999-01-01 to 2019-01-01 already set to: "Paris"')
           end
 
@@ -278,7 +277,7 @@ FILE
       describe 'when preceding default location is different' do
         let(:preceding_activity) { "1999-01-01: Went to _Berlin_"}
         
-        describe 'when proceeding default location is the same' do
+        describe 'when following default location is the same' do
           let(:following_activity) { "2019-01-01: Relocated to _Paris_"}
 
           it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
@@ -287,10 +286,10 @@ FILE
 
         end  
 
-        describe 'when proceeding default location is different' do
+        describe 'when following default location is different' do
           let(:following_activity) { "2019-01-01: Relocated to _Berlin_"}
 
-          it 'prints "Default location from [ADDED ACTIVITY DATE] to [PROCEEDING ACTIVITY DATE] set to" output message' do
+          it 'prints "Default location from [ADDED ACTIVITY DATE] to [FOLLOWING ACTIVITY DATE] set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to 2019-01-01 set to: "Paris"')
           end
         end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -54,7 +54,7 @@ FILE
   describe "adding default location" do
     subject { run_cmd("add activity 2017-01-01: Moved to _Paris_") }
 
-    describe "when default location has not been set before" do
+    describe "when a default location has never been set before" do
     let(:content) do
       <<-FILE
 ### Activities:
@@ -69,12 +69,15 @@ FILE
 FILE
     end
 
-      it 'prints "Default location set to" output message' do
-        value(subject[:stdout].must_include('Default location set to: "Paris"'))
+      focus; it 'prints "Default location set to" output message' do
+        stdout_for_testing = strip_out_activity(subject[:stdout])
+        
+        stdout_for_testing.size.must_equal 1
+        value(stdout_for_testing.must_include('Default location set to: "Paris"'))
       end
     end
 
-    describe "when default location has been set two default locations ago" do
+    describe "when current default location was already set before the last default location" do
     let(:content) do
       <<-FILE
 ### Activities:
@@ -91,12 +94,15 @@ FILE
 FILE
     end
 
-      it 'prints "Default location set to" output message' do
-        value(subject[:stdout].must_include('Default location set to: "Paris"'))
+      focus; it 'prints "Default location set to" output message' do
+        stdout_for_testing = strip_out_activity(subject[:stdout])
+        
+        stdout_for_testing.size.must_equal 1
+        value(stdout_for_testing.must_include('Default location set to: "Paris"'))
       end
     end
 
-    describe "when default location has already been set immediately before" do
+    describe "when current default location is the same as the last default location" do
     let(:content) do
       <<-FILE
 ### Activities:
@@ -111,11 +117,20 @@ FILE
 FILE
     end
 
-      it 'prints "Default location already set to" output message' do
-        value(subject[:stdout].must_include('Default location already set to: "Paris"'))
+      focus; it 'prints "Default location already set to" output message' do
+        stdout_for_testing = strip_out_activity(subject[:stdout])
+
+        stdout_for_testing.size.must_equal 1
+        value(stdout_for_testing.must_include('Default location already set to: "Paris"'))
       end
     end
   end
 
   parsing_specs(event: :activity)
+
+private
+  def strip_out_activity(output)
+    lines = output.split("\n")
+    lines.reject {|line| !line.include?("Default")}
+  end
 end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -315,7 +315,6 @@ FILE
 - 2018-01-01: Went to _Berlin_
 - 2019-01-01: Went to _Paris_
 
-
 ### Notes:
 
 ### Friends:

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -71,7 +71,7 @@ FILE
       let(:activity) { "Had dinner in _Paris_" }
 
       it 'prints "Default location added" output message' do
-        value(subject[:stdout].include? 'Default location set to: "Paris"').must_equal true 
+        value(subject[:stdout].must_include 'Default location set to: "Paris"')
       end
     end
 
@@ -79,7 +79,7 @@ FILE
       let(:activity) { "Went to _Paris_ for a holiday" }
 
       it 'does not print "Default location added" output message' do
-        value(subject[:stdout].include? 'Default location set to: "Paris"').must_equal false 
+        value(subject[:stdout].wont_include 'Default location set to: "Paris"')
       end
     end    
 

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -70,7 +70,6 @@ FILE
       describe "when there is no preceding default location" do
         let(:preceding_activity) { "2016-01-01: Went to the library." }
 
-
         it 'prints "Default location set to" output message' do
           assert_default_location_output('Default location set to: "Paris"')
         end
@@ -95,7 +94,7 @@ FILE
     describe "when it is not the latest activity" do
       subject { run_cmd("add activity 2009-01-01: Moved to _Paris_") }
       let(:content) do
-  <<-FILE
+        <<-FILE
 ### Activities:
 - #{following_activity}
 - #{preceding_activity}
@@ -109,33 +108,30 @@ FILE
       end
 
       describe "when there is no following default location" do
-        let(:following_activity) { "2019-01-01: Visited a cafe"}
+        let(:following_activity) { "2019-01-01: Visited a cafe" }
 
         describe "when there is no preceding default location" do
-          let(:preceding_activity) { "1999-01-01: Visited a library"}
+          let(:preceding_activity) { "1999-01-01: Visited a library" }
 
           it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
           end
-
         end
 
         describe "when preceding default location is different" do
-          let(:preceding_activity) { "1999-01-01: Went to _Berlin_"}
+          let(:preceding_activity) { "1999-01-01: Went to _Berlin_" }
 
           it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
           end
-
         end
 
         describe "when preceding default location is same" do
-          let(:preceding_activity) { "1999-01-01: Went to _Paris_"}
+          let(:preceding_activity) { "1999-01-01: Went to _Paris_" }
 
           it 'prints "Default location from [PRECEDING DEFAULT LOCATION ACTIVITY DATE] to present already set to" output message' do
             assert_default_location_output('Default location from 1999-01-01 to present already set to: "Paris"')
           end
-
         end
 
         describe "when multiple preceding default locations are same and consecutive" do
@@ -157,7 +153,6 @@ FILE
           it 'prints "Default location from [EARLIEST CONSECUTIVE DEFAULT LOCATION ACTIVITY DATE] to present already set to" output message' do
             assert_default_location_output('Default location from 1989-01-01 to present already set to: "Paris"')
           end
-
         end
 
         describe "when multiple preceding default locations are the same but not consecutive" do
@@ -180,30 +175,26 @@ FILE
           it 'prints "Default location from [EARLIEST CONSECUTIVE DEFAULT LOCATION ACTIVITY DATE] to present already set to" output message' do
             assert_default_location_output('Default location from 1999-01-01 to present already set to: "Paris"')
           end
-
         end
-
       end
 
-      describe 'when there are no preceding default locations' do
-        let(:preceding_activity) { "1999-01-01: Visited a cafe"}
+      describe "when there are no preceding default locations" do
+        let(:preceding_activity) { "1999-01-01: Visited a cafe" }
 
-        describe 'when following default location is the same' do
-          let(:following_activity) { "2019-01-01: Went to _Paris_"}
+        describe "when following default location is the same" do
+          let(:following_activity) { "2019-01-01: Went to _Paris_" }
 
           it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
           end
-
         end
 
-        describe 'when following default location is different' do
-          let(:following_activity) { "2019-01-01: Went to _Berlin_"}
+        describe "when following default location is different" do
+          let(:following_activity) { "2019-01-01: Went to _Berlin_" }
 
           it 'prints "Default location from [ADDED ACTIVITY DATE] to [NEXT DIFFERENT DEFAULT LOCATION ACIVITY DATE] set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to 2019-01-01 set to: "Paris"')
           end
-
         end
 
         describe "when multiple following default locations are the same and consecutive" do
@@ -224,7 +215,6 @@ FILE
           it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
           end
-
         end
 
         describe "when multiple following default locations are the same but not consecutive" do
@@ -246,48 +236,42 @@ FILE
           it 'prints "Default location from [ADDED ACTIVITY DATE] to [NEXT DIFFERENT DEFAULT LOCATION ACIVITY DATE] set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to 2018-01-01 set to: "Paris"')
           end
-
         end
-
       end
 
-      describe 'when preceding default location is the same' do
-        let(:preceding_activity) { "1999-01-01: Went to _Paris_"}
-        
-        describe 'when following default location is the same' do
-          let(:following_activity) { "2019-01-01: Relocated to _Paris_"}
+      describe "when preceding default location is the same" do
+        let(:preceding_activity) { "1999-01-01: Went to _Paris_" }
+
+        describe "when following default location is the same" do
+          let(:following_activity) { "2019-01-01: Relocated to _Paris_" }
 
           it 'prints "Default location from [PRECEDING ACTIVITY DATE] to present already set to" output message' do
             assert_default_location_output('Default location from 1999-01-01 to present already set to: "Paris"')
           end
+        end
 
-        end  
-
-        describe 'when following default location is different' do
-          let(:following_activity) { "2019-01-01: Relocated to _Berlin_"}
+        describe "when following default location is different" do
+          let(:following_activity) { "2019-01-01: Relocated to _Berlin_" }
 
           it 'prints "Default location from [PRECEDING ACTIVITY DATE] to [FOLLOWING ACTIVITY DATE] set to" output message' do
             assert_default_location_output('Default location from 1999-01-01 to 2019-01-01 already set to: "Paris"')
           end
-
         end
-
       end
 
-      describe 'when preceding default location is different' do
-        let(:preceding_activity) { "1999-01-01: Went to _Berlin_"}
-        
-        describe 'when following default location is the same' do
-          let(:following_activity) { "2019-01-01: Relocated to _Paris_"}
+      describe "when preceding default location is different" do
+        let(:preceding_activity) { "1999-01-01: Went to _Berlin_" }
+
+        describe "when following default location is the same" do
+          let(:following_activity) { "2019-01-01: Relocated to _Paris_" }
 
           it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
           end
+        end
 
-        end  
-
-        describe 'when following default location is different' do
-          let(:following_activity) { "2019-01-01: Relocated to _Berlin_"}
+        describe "when following default location is different" do
+          let(:following_activity) { "2019-01-01: Relocated to _Berlin_" }
 
           it 'prints "Default location from [ADDED ACTIVITY DATE] to [FOLLOWING ACTIVITY DATE] set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to 2019-01-01 set to: "Paris"')
@@ -295,9 +279,9 @@ FILE
         end
       end
 
-      describe 'when activities are out of order' do
+      describe "when activities are out of order" do
         let(:content) do
-      <<-FILE
+          <<-FILE
 ### Activities:
 - 2018-01-01: Went to _Berlin_
 - 2019-01-01: Went to _Paris_
@@ -333,5 +317,4 @@ FILE
     lines = output.split("\n")
     lines.select { |line| line.include?("Default") }
   end
-
 end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -240,6 +240,27 @@ FILE
           assert_default_location_output('Default location from 1980-01-01 to 2016-01-01 already set to: "Paris"')
         end
       end
+
+      describe "when default location precedes a different default location and preceeds the same default location" do
+        let(:content) do
+          <<-FILE
+### Activities:
+- 2016-01-01: Flew to _Berlin_.
+- 2015-01-01: Flew to _Paris_.
+
+### Notes:
+
+### Friends:
+
+### Locations:
+- Berlin
+FILE
+        end
+
+        focus; it 'prints "Default location from [DATE] to [DATE] already set to" output message' do
+          assert_default_location_output('Default location from 1999-01-01 to 2016-01-01 set to: "Paris"')
+        end
+      end
     end
   end
 

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -162,7 +162,7 @@ FILE
 
         end
 
-        describe "when multiple consecutive preceding activity default locations are same" do
+        describe "when multiple preceding activity default locations are same and consecutive" do
           let(:preceeding_activity) { "1999-01-01: Went to _Paris_"}
           let(:content) do
             <<-FILE
@@ -179,8 +179,32 @@ FILE
 FILE
           end
 
-          focus; it 'prints "Default location from [EARLIEST DEAFULAT LOCATION ACTIVITY DATE] to present already set to" output message' do
+          focus; it 'prints "Default location from [EARLIEST CONSECUTIVE DEFAULT LOCATION ACTIVITY DATE] to present already set to" output message' do
             assert_default_location_output('Default location from 1989-01-01 to present already set to: "Paris"')
+          end
+
+        end
+
+        describe "when multiple preceding activity default locations are the same but not consecutive" do
+          let(:preceeding_activity) { "1999-01-01: Went to _Paris_"}
+          let(:content) do
+            <<-FILE
+### Activities:
+- 2019-01-01: Vistied a cafe
+- 1999-01-01: Went to _Paris_
+- 1989-01-01: Went to _Berlin_
+- 1979-01-01: Relocated to _Paris_
+
+### Notes:
+
+### Friends:
+
+### Locations:
+FILE
+          end
+
+          focus; it 'prints "Default location from [EARLIEST CONSECUTIVE DEFAULT LOCATION ACTIVITY DATE] to present already set to" output message' do
+            assert_default_location_output('Default location from 1999-01-01 to present already set to: "Paris"')
           end
 
         end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -74,7 +74,29 @@ FILE
       end
     end
 
-    describe "when default location has already been set" do
+    describe "when default location has been set two default locations ago" do
+    let(:content) do
+      <<-FILE
+### Activities:
+- 2016-01-01: Moved to _Berlin_.
+- 2015-01-01: Flew to _Paris_.
+
+### Notes:
+
+### Friends:
+
+### Locations:
+- Berlin
+- Paris
+FILE
+    end
+
+      focus; it 'prints "Default location set to" output message' do
+        value(subject[:stdout].must_include('Default location set to: "Paris"'))
+      end
+    end
+
+    describe "when default location has already been set immediately before" do
     let(:content) do
       <<-FILE
 ### Activities:

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -149,6 +149,31 @@ FILE
         end
 
       end
+
+      describe 'when default location is the same as the preceding default location' do
+      let(:content) do
+      <<-FILE
+### Activities:
+- 2016-01-01: Visited my favourite cafe.
+- 1980-01-01: Flew to _Paris_.
+
+### Notes:
+
+### Friends:
+
+### Locations:
+- Paris
+FILE
+      end
+
+      focus;it 'prints "Default location from [DATE] to present already set to" output message' do
+        stdout_for_testing = strip_out_activity(subject[:stdout])
+
+        stdout_for_testing.size.must_equal 1
+        value(stdout_for_testing.must_include('Default location from 1980-01-01 to present already set to: "Paris"'))
+      end
+
+      end
     end
   end
 

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -89,7 +89,7 @@ FILE
 FILE
     end
 
-      focus; it 'prints "Default location already set to" output message' do
+      it 'prints "Default location already set to" output message' do
         value(subject[:stdout].must_include('Default location already set to: "Paris"'))
       end
     end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -70,12 +70,12 @@ FILE
 FILE
         end
 
-        focus; it 'prints "Default location set to" output message' do
+        it 'prints "Default location set to" output message' do
           assert_default_location_output('Default location set to: "Paris"')
         end
       end
 
-      describe "when default location is different to the last default location" do
+      describe "when default location is different to preceding default location" do
         let(:content) do
           <<-FILE
 ### Activities:
@@ -90,12 +90,12 @@ FILE
 FILE
         end
 
-        focus; it 'prints "Default location set to" output message' do
+        it 'prints "Default location set to" output message' do
           assert_default_location_output('Default location set to: "Paris"')
         end
       end
 
-      describe "when default location is the same as the last default location" do
+      describe "when default location is the same as preceding location" do
         let(:content) do
           <<-FILE
 ### Activities:
@@ -110,20 +110,19 @@ FILE
 FILE
         end
 
-        focus; it 'prints "Default location already set to" output message' do
+        it 'prints "Default location already set to" output message' do
           assert_default_location_output('Default location already set to: "Paris"')
         end
       end
     end
 
     describe "when it is not the latest activity" do
-      subject { run_cmd("add activity 1999-01-01: Moved to _Paris_") }
-
-      describe "when default location has never been set before" do
-        let(:content) do
-          <<-FILE
+      subject { run_cmd("add activity 2009-01-01: Moved to _Paris_") }
+      let(:content) do
+  <<-FILE
 ### Activities:
-- 2016-01-01: Visited my favourite cafe.
+- #{proceeding_activity}
+- #{preceeding_activity}
 
 ### Notes:
 
@@ -131,136 +130,207 @@ FILE
 
 ### Locations:
 FILE
-        end
-
-        focus; it 'prints "Default location from [DATE] to present set to" output message' do
-          assert_default_location_output('Default location from 1999-01-01 to present set to: "Paris"')
-        end
       end
 
-      describe "when default location is the same as the preceding default location" do
-        let(:content) do
-          <<-FILE
+      describe "when proceeding activities have no default location" do
+        let(:proceeding_activity) { "2019-01-01: Vistied a cafe"}
+
+        describe "when preceding activities have no default location" do
+          let(:preceeding_activity) { "1999-01-01: Vistied a library"}
+
+          focus; it 'prints "Default location from [SUBJECT DATE] to present set to" output message' do
+            assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
+          end
+
+        end
+
+        describe "when preceding activity default location is different" do
+          let(:preceeding_activity) { "1999-01-01: Went to _Berlin_"}
+
+          focus; it 'prints "Default location from [SUBJECT DATE] to present set to" output message' do
+            assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
+          end
+
+        end
+
+        describe "when preceding activity default location is same" do
+          let(:preceeding_activity) { "1999-01-01: Went to _Paris_"}
+
+          focus; it 'prints "Default location from [PRECEDING ACTIVITY DATE] to present already set to" output message' do
+            assert_default_location_output('Default location from 1999-01-01 to present already set to: "Paris"')
+          end
+
+        end
+
+        describe "when multiple consecutive preceding activity default locations are same" do
+          let(:preceeding_activity) { "1999-01-01: Went to _Paris_"}
+          let(:content) do
+            <<-FILE
 ### Activities:
-- 2016-01-01: Visited my favourite cafe.
-- 1980-01-01: Flew to _Paris_.
+- 2019-01-01: Vistied a cafe
+- 1999-01-01: Went to _Paris_
+- 1989-01-01: Relocated to _Paris_
 
 ### Notes:
 
 ### Friends:
 
 ### Locations:
-- Paris
 FILE
+          end
+
+          focus; it 'prints "Default location from [EARLIEST DEAFULAT LOCATION ACTIVITY DATE] to present already set to" output message' do
+            assert_default_location_output('Default location from 1989-01-01 to present already set to: "Paris"')
+          end
+
         end
 
-        focus; it 'prints "Default location from [DATE] to present already set to" output message' do
-          assert_default_location_output('Default location from 1980-01-01 to present already set to: "Paris"')
-        end
       end
 
-      describe 'when default location is different to preceding default location' do
-        let(:content) do
-          <<-FILE
-### Activities:
-- 2016-01-01: Visited my favourite cafe.
-- 1980-01-01: Flew to _Berlin_.
 
-### Notes:
 
-### Friends:
+#       describe "when default location has never been set before" do
+#         let(:content) do
+#           <<-FILE
+# ### Activities:
+# - 2016-01-01: Visited my favourite cafe.
 
-### Locations:
-- Berlin
-FILE
-        end
+# ### Notes:
 
-        focus; it 'prints "Default location from [DATE] to present set to" output message' do
-          assert_default_location_output('Default location from 1999-01-01 to present set to: "Paris"')
-        end
-      end
+# ### Friends:
 
-      describe "when default location precedes the same default location" do
-        let(:content) do
-          <<-FILE
-### Activities:
-- 2016-01-01: Flew to _Paris_.
+# ### Locations:
+# FILE
+#         end
 
-### Notes:
+#         focus; it 'prints "Default location from [DATE] to present set to" output message' do
+#           assert_default_location_output('Default location from 1999-01-01 to present set to: "Paris"')
+#         end
+#       end
 
-### Friends:
+#       describe "when default location is the same as the preceding default location" do
+#         let(:content) do
+#           <<-FILE
+# ### Activities:
+# - 2016-01-01: Visited my favourite cafe.
+# - 1980-01-01: Flew to _Paris_.
 
-### Locations:
-- Paris
-FILE
-        end
+# ### Notes:
 
-        focus; it 'prints "Default location from [DATE] to present set to" output message' do
-          assert_default_location_output('Default location from 1999-01-01 to present set to: "Paris"')
-        end
-      end
+# ### Friends:
 
-      describe "when default location precedes a different default location" do
-        let(:content) do
-          <<-FILE
-### Activities:
-- 2016-01-01: Flew to _Berlin_.
+# ### Locations:
+# - Paris
+# FILE
+#         end
 
-### Notes:
+#         focus; it 'prints "Default location from [DATE] to present already set to" output message' do
+#           assert_default_location_output('Default location from 1980-01-01 to present already set to: "Paris"')
+#         end
+#       end
 
-### Friends:
+#       describe 'when default location is different to preceding default location' do
+#         let(:content) do
+#           <<-FILE
+# ### Activities:
+# - 2016-01-01: Visited my favourite cafe.
+# - 1980-01-01: Flew to _Berlin_.
 
-### Locations:
-- Berlin
-FILE
-        end
+# ### Notes:
 
-        focus; it 'prints "Default location from [DATE] to [DATE] set to" output message' do
-          assert_default_location_output('Default location from 1999-01-01 to 2016-01-01 set to: "Paris"')
-        end
-      end
+# ### Friends:
 
-      describe "when default location precedes a different default location and proceeds the same default location" do
-        let(:content) do
-          <<-FILE
-### Activities:
-- 2016-01-01: Flew to _Berlin_.
-- 1980-01-01: Flew to _Paris_.
+# ### Locations:
+# - Berlin
+# FILE
+#         end
 
-### Notes:
+#         focus; it 'prints "Default location from [DATE] to present set to" output message' do
+#           assert_default_location_output('Default location from 1999-01-01 to present set to: "Paris"')
+#         end
+#       end
 
-### Friends:
+#       describe "when default location precedes the same default location" do
+#         let(:content) do
+#           <<-FILE
+# ### Activities:
+# - 2016-01-01: Flew to _Paris_.
 
-### Locations:
-- Berlin
-FILE
-        end
+# ### Notes:
 
-        focus; it 'prints "Default location from [DATE] to [DATE] already set to" output message' do
-          assert_default_location_output('Default location from 1980-01-01 to 2016-01-01 already set to: "Paris"')
-        end
-      end
+# ### Friends:
 
-      describe "when default location precedes a different default location and preceeds the same default location" do
-        let(:content) do
-          <<-FILE
-### Activities:
-- 2016-01-01: Flew to _Berlin_.
-- 2015-01-01: Flew to _Paris_.
+# ### Locations:
+# - Paris
+# FILE
+#         end
 
-### Notes:
+#         focus; it 'prints "Default location from [DATE] to present set to" output message' do
+#           assert_default_location_output('Default location from 1999-01-01 to present set to: "Paris"')
+#         end
+#       end
 
-### Friends:
+#       describe "when default location precedes a different default location" do
+#         let(:content) do
+#           <<-FILE
+# ### Activities:
+# - 2016-01-01: Flew to _Berlin_.
 
-### Locations:
-- Berlin
-FILE
-        end
+# ### Notes:
 
-        focus; it 'prints "Default location from [DATE] to [DATE] already set to" output message' do
-          assert_default_location_output('Default location from 1999-01-01 to 2016-01-01 set to: "Paris"')
-        end
-      end
+# ### Friends:
+
+# ### Locations:
+# - Berlin
+# FILE
+#         end
+
+#         focus; it 'prints "Default location from [DATE] to [DATE] set to" output message' do
+#           assert_default_location_output('Default location from 1999-01-01 to 2016-01-01 set to: "Paris"')
+#         end
+#       end
+
+#       describe "when default location precedes a different default location and proceeds the same default location" do
+#         let(:content) do
+#           <<-FILE
+# ### Activities:
+# - 2016-01-01: Flew to _Berlin_.
+# - 1980-01-01: Flew to _Paris_.
+
+# ### Notes:
+
+# ### Friends:
+
+# ### Locations:
+# - Berlin
+# FILE
+#         end
+
+#         focus; it 'prints "Default location from [DATE] to [DATE] already set to" output message' do
+#           assert_default_location_output('Default location from 1980-01-01 to 2016-01-01 already set to: "Paris"')
+#         end
+#       end
+
+#       describe "when default location precedes a different default location and preceeds the same default location" do
+#         let(:content) do
+#           <<-FILE
+# ### Activities:
+# - 2016-01-01: Flew to _Berlin_.
+# - 2015-01-01: Flew to _Paris_.
+
+# ### Notes:
+
+# ### Friends:
+
+# ### Locations:
+# - Berlin
+# FILE
+#         end
+
+#         focus; it 'prints "Default location from [DATE] to [DATE] already set to" output message' do
+#           assert_default_location_output('Default location from 1999-01-01 to 2016-01-01 set to: "Paris"')
+#         end
+#       end
     end
   end
 

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -109,10 +109,10 @@ FILE
       end
 
       describe "when proceeding activities have no default location" do
-        let(:following_activity) { "2019-01-01: Visted a cafe"}
+        let(:following_activity) { "2019-01-01: Visited a cafe"}
 
         describe "when preceding activities have no default location" do
-          let(:preceding_activity) { "1999-01-01: Visted a library"}
+          let(:preceding_activity) { "1999-01-01: Visited a library"}
 
           it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
@@ -143,7 +143,7 @@ FILE
           let(:content) do
             <<-FILE
 ### Activities:
-- 2019-01-01: Visted a cafe
+- 2019-01-01: Visited a cafe
 - 1999-01-01: Went to _Paris_
 - 1989-01-01: Relocated to _Paris_
 
@@ -165,7 +165,7 @@ FILE
           let(:content) do
             <<-FILE
 ### Activities:
-- 2019-01-01: Visted a cafe
+- 2019-01-01: Visited a cafe
 - 1999-01-01: Went to _Paris_
 - 1989-01-01: Went to _Berlin_
 - 1979-01-01: Relocated to _Paris_
@@ -187,7 +187,7 @@ FILE
       end
 
       describe 'when preceding activities have no default locations' do
-        let(:preceding_activity) { "1999-01-01: Visted a cafe"}
+        let(:preceding_activity) { "1999-01-01: Visited a cafe"}
 
         describe 'when single proceeding default location is the same' do
           let(:following_activity) { "2019-01-01: Went to _Paris_"}

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -71,10 +71,7 @@ FILE
         end
 
         it 'prints "Default location set to" output message' do
-          stdout_for_testing = strip_out_activity(subject[:stdout])
-
-          stdout_for_testing.size.must_equal 1
-          value(stdout_for_testing.must_include('Default location set to: "Paris"'))
+          assert_default_location_output('Default location set to: "Paris"')
         end
       end
 
@@ -94,10 +91,7 @@ FILE
         end
 
         it 'prints "Default location set to" output message' do
-          stdout_for_testing = strip_out_activity(subject[:stdout])
-
-          stdout_for_testing.size.must_equal 1
-          value(stdout_for_testing.must_include('Default location set to: "Paris"'))
+          assert_default_location_output('Default location set to: "Paris"')
         end
       end
 
@@ -117,10 +111,7 @@ FILE
         end
 
         it 'prints "Default location already set to" output message' do
-          stdout_for_testing = strip_out_activity(subject[:stdout])
-
-          stdout_for_testing.size.must_equal 1
-          value(stdout_for_testing.must_include('Default location already set to: "Paris"'))
+          assert_default_location_output('Default location already set to: "Paris"')
         end
       end
     end
@@ -143,10 +134,7 @@ FILE
         end
 
         it 'prints "Default location from [DATE] to present set to" output message' do
-          stdout_for_testing = strip_out_activity(subject[:stdout])
-
-          stdout_for_testing.size.must_equal 1
-          value(stdout_for_testing.must_include('Default location from 1999-01-01 to present set to: "Paris"'))
+          assert_default_location_output('Default location from 1999-01-01 to present set to: "Paris"')
         end
       end
 
@@ -167,10 +155,7 @@ FILE
         end
 
         it 'prints "Default location from [DATE] to present already set to" output message' do
-          stdout_for_testing = strip_out_activity(subject[:stdout])
-
-          stdout_for_testing.size.must_equal 1
-          value(stdout_for_testing.must_include('Default location from 1980-01-01 to present already set to: "Paris"'))
+          assert_default_location_output('Default location from 1980-01-01 to present already set to: "Paris"')
         end
       end
 
@@ -190,10 +175,7 @@ FILE
         end
 
         it 'prints "Default location from [DATE] to [DATE] set to" output message' do
-          stdout_for_testing = strip_out_activity(subject[:stdout])
-
-          stdout_for_testing.size.must_equal 1
-          value(stdout_for_testing.must_include('Default location from 1999-01-01 to 2016-01-01 set to: "Paris"'))
+          assert_default_location_output('Default location from 1999-01-01 to 2016-01-01 set to: "Paris"')
         end
       end
 
@@ -214,10 +196,7 @@ FILE
         end
 
         it 'prints "Default location from [DATE] to [DATE] already set to" output message' do
-          stdout_for_testing = strip_out_activity(subject[:stdout])
-
-          stdout_for_testing.size.must_equal 1
-          value(stdout_for_testing.must_include('Default location from 1980-01-01 to 2016-01-01 already set to: "Paris"'))
+          assert_default_location_output('Default location from 1980-01-01 to 2016-01-01 already set to: "Paris"')
         end
       end
     end
@@ -227,8 +206,16 @@ FILE
 
   private
 
-  def strip_out_activity(output)
+  def assert_default_location_output(expected_output)
+    output = select_default_activity_output(subject[:stdout])
+
+    output.size.must_equal(1)
+    output.must_include(expected_output)
+  end
+
+  def select_default_activity_output(output)
     lines = output.split("\n")
     lines.select { |line| line.include?("Default") }
   end
+
 end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -323,8 +323,7 @@ FILE
 FILE
         end
 
-        it  "prints 'Default location from " \
-            "[ADDED ACTIVITY DATE] to [FOLLOWING ACTIVITY DATE] set to [LOCATION]'" do
+        it  "uses the sorted order for determining output" do
           output = 'Default location from 2009-01-01 to 2018-01-01 set to: "Paris"'
           assert_default_location_output(output)
         end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -70,7 +70,7 @@ FILE
     describe "when default location has not been set before" do
       let(:activity) { "Had dinner in _Paris_" }
 
-      it 'prints "Default location added" output message' do
+      it 'prints "Default location set to" output message' do
         value(subject[:stdout].must_include('Default location set to: "Paris"'))
       end
     end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -52,63 +52,39 @@ FILE
   end
 
   describe "adding default location" do
-    describe "when it is the lastest activity" do
+    describe "when it is the latest activity" do
       subject { run_cmd("add activity Moved to _Paris_") }
+      let(:content) do
+        <<-FILE
+### Activities:
+- #{preceding_activity}
+
+### Notes:
+
+### Friends:
+
+### Locations:
+FILE
+      end
 
       describe "when a default location has never been set before" do
-        let(:content) do
-          <<-FILE
-### Activities:
-- 2016-01-01: Had dinner in _Berlin_.
+        let(:preceding_activity) { "2016-01-01: Had dinner in _Berlin_." }
 
-### Notes:
-
-### Friends:
-
-### Locations:
-- Berlin
-FILE
-        end
 
         it 'prints "Default location set to" output message' do
           assert_default_location_output('Default location set to: "Paris"')
         end
       end
 
-      describe "when default location is different to preceding default location" do
-        let(:content) do
-          <<-FILE
-### Activities:
-- 2016-01-01: Moved to _Berlin_.
-
-### Notes:
-
-### Friends:
-
-### Locations:
-- Berlin
-FILE
-        end
-
+      describe "when preceding default location is different" do
+        let(:preceding_activity) { "2016-01-01: Moved to _Berlin_." }
         it 'prints "Default location set to" output message' do
           assert_default_location_output('Default location set to: "Paris"')
         end
       end
 
-      describe "when default location is the same as preceding location" do
-        let(:content) do
-          <<-FILE
-### Activities:
-- 2016-01-01: Flew to _Paris_.
-
-### Notes:
-
-### Friends:
-
-### Locations:
-- Paris
-FILE
-        end
+      describe "when preceding default location is the same" do
+        let(:preceding_activity) { "2016-01-01: Flew to _Paris_." }
 
         it 'prints "Default location already set to" output message' do
           assert_default_location_output('Default location already set to: "Paris"')
@@ -138,31 +114,31 @@ FILE
         describe "when preceding activities have no default location" do
           let(:preceding_activity) { "1999-01-01: Visted a library"}
 
-          focus; it 'prints "Default location from [SUBJECT DATE] to present set to" output message' do
+          it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
           end
 
         end
 
-        describe "when preceding activity default location is different" do
+        describe "when preceding default location is different" do
           let(:preceding_activity) { "1999-01-01: Went to _Berlin_"}
 
-          focus; it 'prints "Default location from [SUBJECT DATE] to present set to" output message' do
+          it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
           end
 
         end
 
-        describe "when preceding activity default location is same" do
+        describe "when preceding default location is same" do
           let(:preceding_activity) { "1999-01-01: Went to _Paris_"}
 
-          focus; it 'prints "Default location from [PRECEDING ACTIVITY DATE] to present already set to" output message' do
+          it 'prints "Default location from [PRECEDING ACTIVITY DATE] to present already set to" output message' do
             assert_default_location_output('Default location from 1999-01-01 to present already set to: "Paris"')
           end
 
         end
 
-        describe "when multiple preceding activity default locations are same and consecutive" do
+        describe "when multiple preceding default locations are same and consecutive" do
           let(:preceding_activity) { "1999-01-01: Went to _Paris_"}
           let(:content) do
             <<-FILE
@@ -179,13 +155,13 @@ FILE
 FILE
           end
 
-          focus; it 'prints "Default location from [EARLIEST CONSECUTIVE DEFAULT LOCATION ACTIVITY DATE] to present already set to" output message' do
+          it 'prints "Default location from [EARLIEST CONSECUTIVE DEFAULT LOCATION ACTIVITY DATE] to present already set to" output message' do
             assert_default_location_output('Default location from 1989-01-01 to present already set to: "Paris"')
           end
 
         end
 
-        describe "when multiple preceding activity default locations are the same but not consecutive" do
+        describe "when multiple preceding default locations are the same but not consecutive" do
           let(:content) do
             <<-FILE
 ### Activities:
@@ -202,7 +178,7 @@ FILE
 FILE
           end
 
-          focus; it 'prints "Default location from [EARLIEST CONSECUTIVE DEFAULT LOCATION ACTIVITY DATE] to present already set to" output message' do
+          it 'prints "Default location from [EARLIEST CONSECUTIVE DEFAULT LOCATION ACTIVITY DATE] to present already set to" output message' do
             assert_default_location_output('Default location from 1999-01-01 to present already set to: "Paris"')
           end
 
@@ -213,25 +189,25 @@ FILE
       describe 'when preceding activities have no default locations' do
         let(:preceding_activity) { "1999-01-01: Visted a cafe"}
 
-        describe 'when single proceeding activity has the same default location' do
+        describe 'when single proceeding default location is the same' do
           let(:proceeding_activity) { "2019-01-01: Went to _Paris_"}
 
-          focus; it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
+          it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
           end
 
         end
 
-        describe 'when proceeding activity has different default location' do
+        describe 'when proceeding default location is different' do
           let(:proceeding_activity) { "2019-01-01: Went to _Berlin_"}
 
-          focus; it 'prints "Default location from [ADDED ACTIVITY DATE] to [DIFFERENT DEFAULT LOCATION ACTIVITY DATE] set to" output message' do
+          it 'prints "Default location from [ADDED ACTIVITY DATE] to [DIFFERENT DEFAULT LOCATION ACTIVITY DATE] set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to 2019-01-01 set to: "Paris"')
           end
 
         end
 
-        describe "when multiple proceeding activity default locations are the same and consecutive" do
+        describe "when multiple proceeding default locations are the same and consecutive" do
           let(:content) do
             <<-FILE
 ### Activities:
@@ -246,13 +222,13 @@ FILE
 FILE
           end
 
-          focus; it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
+          it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
           end
 
         end
 
-        describe "when multiple proceeding activity default locations are the same but not consecutive" do
+        describe "when multiple proceeding default locations are the same but not consecutive" do
           let(:content) do
             <<-FILE
 ### Activities:
@@ -268,7 +244,7 @@ FILE
 FILE
           end
 
-          focus; it 'prints "Default location from [ADDED ACTIVITY DATE] to [NEXT DIFFERENT DEFAULT LOCATION ACIVITY DATE] set to" output message' do
+          it 'prints "Default location from [ADDED ACTIVITY DATE] to [NEXT DIFFERENT DEFAULT LOCATION ACIVITY DATE] set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to 2018-01-01 set to: "Paris"')
           end
 
@@ -276,22 +252,22 @@ FILE
 
       end
 
-      describe 'when preceding activity has the same default location' do
+      describe 'when preceding default location is the same' do
         let(:preceding_activity) { "1999-01-01: Went to _Paris_"}
         
-        describe 'when proceeding activity has the same default location' do
+        describe 'when proceeding default location is the same' do
           let(:proceeding_activity) { "2019-01-01: Relocated to _Paris_"}
 
-          focus; it 'prints "Default location from [PRECEDING ACTIVITY LOCATION DATE] to present set to" output message' do
+          it 'prints "Default location from [PRECEDING ACTIVITY DATE] to present set to" output message' do
             assert_default_location_output('Default location from 1999-01-01 to present already set to: "Paris"')
           end
 
         end  
 
-        describe 'when proceeding activity has different default location' do
+        describe 'when proceeding default location is different' do
           let(:proceeding_activity) { "2019-01-01: Relocated to _Berlin_"}
 
-          focus; it 'prints "Default location from [PRECEDING ACTIVITY LOCATION DATE] to [PROCEEDING ACTIVITY DATE] set to" output message' do
+          it 'prints "Default location from [PRECEDING ACTIVITY DATE] to [PROCEEDING ACTIVITY DATE] set to" output message' do
             assert_default_location_output('Default location from 1999-01-01 to 2019-01-01 already set to: "Paris"')
           end
 
@@ -299,173 +275,26 @@ FILE
 
       end
 
-      describe 'when preceding activity has different default location' do
+      describe 'when preceding default location is different' do
         let(:preceding_activity) { "1999-01-01: Went to _Berlin_"}
         
-        describe 'when proceeding activity has the same default location' do
+        describe 'when proceeding default location is the same' do
           let(:proceeding_activity) { "2019-01-01: Relocated to _Paris_"}
 
-          focus; it 'prints "Default location from [ADDED ACTIVITY LOCATION DATE] to present set to" output message' do
+          it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
           end
 
         end  
 
-        describe 'when proceeding activity has different default location' do
+        describe 'when proceeding default location is different' do
           let(:proceeding_activity) { "2019-01-01: Relocated to _Berlin_"}
 
-          focus; it 'prints "Default location from [ADDED ACTIVITY LOCATION DATE] to [PROCEEDING ACTIVITY DATE] set to" output message' do
+          it 'prints "Default location from [ADDED ACTIVITY DATE] to [PROCEEDING ACTIVITY DATE] set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to 2019-01-01 set to: "Paris"')
           end
-
         end
-
       end
-
-
-
-#       describe "when default location has never been set before" do
-#         let(:content) do
-#           <<-FILE
-# ### Activities:
-# - 2016-01-01: Visited my favourite cafe.
-
-# ### Notes:
-
-# ### Friends:
-
-# ### Locations:
-# FILE
-#         end
-
-#         focus; it 'prints "Default location from [DATE] to present set to" output message' do
-#           assert_default_location_output('Default location from 1999-01-01 to present set to: "Paris"')
-#         end
-#       end
-
-#       describe "when default location is the same as the preceding default location" do
-#         let(:content) do
-#           <<-FILE
-# ### Activities:
-# - 2016-01-01: Visited my favourite cafe.
-# - 1980-01-01: Flew to _Paris_.
-
-# ### Notes:
-
-# ### Friends:
-
-# ### Locations:
-# - Paris
-# FILE
-#         end
-
-#         focus; it 'prints "Default location from [DATE] to present already set to" output message' do
-#           assert_default_location_output('Default location from 1980-01-01 to present already set to: "Paris"')
-#         end
-#       end
-
-#       describe 'when default location is different to preceding default location' do
-#         let(:content) do
-#           <<-FILE
-# ### Activities:
-# - 2016-01-01: Visited my favourite cafe.
-# - 1980-01-01: Flew to _Berlin_.
-
-# ### Notes:
-
-# ### Friends:
-
-# ### Locations:
-# - Berlin
-# FILE
-#         end
-
-#         focus; it 'prints "Default location from [DATE] to present set to" output message' do
-#           assert_default_location_output('Default location from 1999-01-01 to present set to: "Paris"')
-#         end
-#       end
-
-#       describe "when default location precedes the same default location" do
-#         let(:content) do
-#           <<-FILE
-# ### Activities:
-# - 2016-01-01: Flew to _Paris_.
-
-# ### Notes:
-
-# ### Friends:
-
-# ### Locations:
-# - Paris
-# FILE
-#         end
-
-#         focus; it 'prints "Default location from [DATE] to present set to" output message' do
-#           assert_default_location_output('Default location from 1999-01-01 to present set to: "Paris"')
-#         end
-#       end
-
-#       describe "when default location precedes a different default location" do
-#         let(:content) do
-#           <<-FILE
-# ### Activities:
-# - 2016-01-01: Flew to _Berlin_.
-
-# ### Notes:
-
-# ### Friends:
-
-# ### Locations:
-# - Berlin
-# FILE
-#         end
-
-#         focus; it 'prints "Default location from [DATE] to [DATE] set to" output message' do
-#           assert_default_location_output('Default location from 1999-01-01 to 2016-01-01 set to: "Paris"')
-#         end
-#       end
-
-#       describe "when default location precedes a different default location and proceeds the same default location" do
-#         let(:content) do
-#           <<-FILE
-# ### Activities:
-# - 2016-01-01: Flew to _Berlin_.
-# - 1980-01-01: Flew to _Paris_.
-
-# ### Notes:
-
-# ### Friends:
-
-# ### Locations:
-# - Berlin
-# FILE
-#         end
-
-#         focus; it 'prints "Default location from [DATE] to [DATE] already set to" output message' do
-#           assert_default_location_output('Default location from 1980-01-01 to 2016-01-01 already set to: "Paris"')
-#         end
-#       end
-
-#       describe "when default location precedes a different default location and preceeds the same default location" do
-#         let(:content) do
-#           <<-FILE
-# ### Activities:
-# - 2016-01-01: Flew to _Berlin_.
-# - 2015-01-01: Flew to _Paris_.
-
-# ### Notes:
-
-# ### Friends:
-
-# ### Locations:
-# - Berlin
-# FILE
-#         end
-
-#         focus; it 'prints "Default location from [DATE] to [DATE] already set to" output message' do
-#           assert_default_location_output('Default location from 1999-01-01 to 2016-01-01 set to: "Paris"')
-#         end
-#       end
     end
   end
 

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -71,7 +71,7 @@ FILE
       let(:activity) { "Had dinner in _Paris_" }
 
       it 'prints "Default location added" output message' do
-        value(subject[:stdout].must_include 'Default location set to: "Paris"')
+        value(subject[:stdout].must_include('Default location set to: "Paris"'))
       end
     end
 
@@ -79,10 +79,9 @@ FILE
       let(:activity) { "Went to _Paris_ for a holiday" }
 
       it 'does not print "Default location added" output message' do
-        value(subject[:stdout].wont_include 'Default location set to: "Paris"')
+        value(subject[:stdout].wont_include('Default location set to: "Paris"'))
       end
-    end    
-
+    end
   end
 
   parsing_specs(event: :activity)

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -294,6 +294,27 @@ FILE
           end
         end
       end
+
+      describe 'when activities are out of order' do
+        let(:content) do
+      <<-FILE
+### Activities:
+- 2018-01-01: Went to _Berlin_
+- 2019-01-01: Went to _Paris_
+
+
+### Notes:
+
+### Friends:
+
+### Locations:
+FILE
+        end
+
+        it 'prints "Default location from [ADDED ACTIVITY DATE] to [FOLLOWING ACTIVITY DATE] set to" output message' do
+          assert_default_location_output('Default location from 2009-01-01 to 2018-01-01 set to: "Paris"')
+        end
+      end
     end
   end
 

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -122,7 +122,7 @@ FILE
   <<-FILE
 ### Activities:
 - #{proceeding_activity}
-- #{preceeding_activity}
+- #{preceding_activity}
 
 ### Notes:
 
@@ -133,10 +133,10 @@ FILE
       end
 
       describe "when proceeding activities have no default location" do
-        let(:proceeding_activity) { "2019-01-01: Vistied a cafe"}
+        let(:proceeding_activity) { "2019-01-01: Visted a cafe"}
 
         describe "when preceding activities have no default location" do
-          let(:preceeding_activity) { "1999-01-01: Vistied a library"}
+          let(:preceding_activity) { "1999-01-01: Visted a library"}
 
           focus; it 'prints "Default location from [SUBJECT DATE] to present set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
@@ -145,7 +145,7 @@ FILE
         end
 
         describe "when preceding activity default location is different" do
-          let(:preceeding_activity) { "1999-01-01: Went to _Berlin_"}
+          let(:preceding_activity) { "1999-01-01: Went to _Berlin_"}
 
           focus; it 'prints "Default location from [SUBJECT DATE] to present set to" output message' do
             assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
@@ -154,7 +154,7 @@ FILE
         end
 
         describe "when preceding activity default location is same" do
-          let(:preceeding_activity) { "1999-01-01: Went to _Paris_"}
+          let(:preceding_activity) { "1999-01-01: Went to _Paris_"}
 
           focus; it 'prints "Default location from [PRECEDING ACTIVITY DATE] to present already set to" output message' do
             assert_default_location_output('Default location from 1999-01-01 to present already set to: "Paris"')
@@ -163,11 +163,11 @@ FILE
         end
 
         describe "when multiple preceding activity default locations are same and consecutive" do
-          let(:preceeding_activity) { "1999-01-01: Went to _Paris_"}
+          let(:preceding_activity) { "1999-01-01: Went to _Paris_"}
           let(:content) do
             <<-FILE
 ### Activities:
-- 2019-01-01: Vistied a cafe
+- 2019-01-01: Visted a cafe
 - 1999-01-01: Went to _Paris_
 - 1989-01-01: Relocated to _Paris_
 
@@ -186,11 +186,10 @@ FILE
         end
 
         describe "when multiple preceding activity default locations are the same but not consecutive" do
-          let(:preceeding_activity) { "1999-01-01: Went to _Paris_"}
           let(:content) do
             <<-FILE
 ### Activities:
-- 2019-01-01: Vistied a cafe
+- 2019-01-01: Visted a cafe
 - 1999-01-01: Went to _Paris_
 - 1989-01-01: Went to _Berlin_
 - 1979-01-01: Relocated to _Paris_
@@ -205,6 +204,118 @@ FILE
 
           focus; it 'prints "Default location from [EARLIEST CONSECUTIVE DEFAULT LOCATION ACTIVITY DATE] to present already set to" output message' do
             assert_default_location_output('Default location from 1999-01-01 to present already set to: "Paris"')
+          end
+
+        end
+
+      end
+
+      describe 'when preceding activities have no default locations' do
+        let(:preceding_activity) { "1999-01-01: Visted a cafe"}
+
+        describe 'when single proceeding activity has the same default location' do
+          let(:proceeding_activity) { "2019-01-01: Went to _Paris_"}
+
+          focus; it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
+            assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
+          end
+
+        end
+
+        describe 'when proceeding activity has different default location' do
+          let(:proceeding_activity) { "2019-01-01: Went to _Berlin_"}
+
+          focus; it 'prints "Default location from [ADDED ACTIVITY DATE] to [DIFFERENT DEFAULT LOCATION ACTIVITY DATE] set to" output message' do
+            assert_default_location_output('Default location from 2009-01-01 to 2019-01-01 set to: "Paris"')
+          end
+
+        end
+
+        describe "when multiple proceeding activity default locations are the same and consecutive" do
+          let(:content) do
+            <<-FILE
+### Activities:
+- 2019-01-01: Went to _Paris_
+- 2018-01-01: Relocated to _Paris_
+
+### Notes:
+
+### Friends:
+
+### Locations:
+FILE
+          end
+
+          focus; it 'prints "Default location from [ADDED ACTIVITY DATE] to present set to" output message' do
+            assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
+          end
+
+        end
+
+        describe "when multiple proceeding activity default locations are the same but not consecutive" do
+          let(:content) do
+            <<-FILE
+### Activities:
+- 2019-01-01: Went to _Paris_
+- 2018-01-01: Went to _Berlin_
+- 2017-01-01: Relocated to _Paris_
+
+### Notes:
+
+### Friends:
+
+### Locations:
+FILE
+          end
+
+          focus; it 'prints "Default location from [ADDED ACTIVITY DATE] to [NEXT DIFFERENT DEFAULT LOCATION ACIVITY DATE] set to" output message' do
+            assert_default_location_output('Default location from 2009-01-01 to 2018-01-01 set to: "Paris"')
+          end
+
+        end
+
+      end
+
+      describe 'when preceding activity has the same default location' do
+        let(:preceding_activity) { "1999-01-01: Went to _Paris_"}
+        
+        describe 'when proceeding activity has the same default location' do
+          let(:proceeding_activity) { "2019-01-01: Relocated to _Paris_"}
+
+          focus; it 'prints "Default location from [PRECEDING ACTIVITY LOCATION DATE] to present set to" output message' do
+            assert_default_location_output('Default location from 1999-01-01 to present already set to: "Paris"')
+          end
+
+        end  
+
+        describe 'when proceeding activity has different default location' do
+          let(:proceeding_activity) { "2019-01-01: Relocated to _Berlin_"}
+
+          focus; it 'prints "Default location from [PRECEDING ACTIVITY LOCATION DATE] to [PROCEEDING ACTIVITY DATE] set to" output message' do
+            assert_default_location_output('Default location from 1999-01-01 to 2019-01-01 already set to: "Paris"')
+          end
+
+        end
+
+      end
+
+      describe 'when preceding activity has different default location' do
+        let(:preceding_activity) { "1999-01-01: Went to _Berlin_"}
+        
+        describe 'when proceeding activity has the same default location' do
+          let(:proceeding_activity) { "2019-01-01: Relocated to _Paris_"}
+
+          focus; it 'prints "Default location from [ADDED ACTIVITY LOCATION DATE] to present set to" output message' do
+            assert_default_location_output('Default location from 2009-01-01 to present set to: "Paris"')
+          end
+
+        end  
+
+        describe 'when proceeding activity has different default location' do
+          let(:proceeding_activity) { "2019-01-01: Relocated to _Berlin_"}
+
+          focus; it 'prints "Default location from [ADDED ACTIVITY LOCATION DATE] to [PROCEEDING ACTIVITY DATE] set to" output message' do
+            assert_default_location_output('Default location from 2009-01-01 to 2019-01-01 set to: "Paris"')
           end
 
         end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -70,12 +70,12 @@ FILE
 FILE
         end
 
-        it 'prints "Default location set to" output message' do
+        focus; it 'prints "Default location set to" output message' do
           assert_default_location_output('Default location set to: "Paris"')
         end
       end
 
-      describe "when current default location is different to the last default location" do
+      describe "when default location is different to the last default location" do
         let(:content) do
           <<-FILE
 ### Activities:
@@ -90,12 +90,12 @@ FILE
 FILE
         end
 
-        it 'prints "Default location set to" output message' do
+        focus; it 'prints "Default location set to" output message' do
           assert_default_location_output('Default location set to: "Paris"')
         end
       end
 
-      describe "when current default location is the same as the last default location" do
+      describe "when default location is the same as the last default location" do
         let(:content) do
           <<-FILE
 ### Activities:
@@ -110,7 +110,7 @@ FILE
 FILE
         end
 
-        it 'prints "Default location already set to" output message' do
+        focus; it 'prints "Default location already set to" output message' do
           assert_default_location_output('Default location already set to: "Paris"')
         end
       end
@@ -119,7 +119,7 @@ FILE
     describe "when it is not the latest activity" do
       subject { run_cmd("add activity 1999-01-01: Moved to _Paris_") }
 
-      describe "when a default location has never been set before" do
+      describe "when default location has never been set before" do
         let(:content) do
           <<-FILE
 ### Activities:
@@ -133,7 +133,7 @@ FILE
 FILE
         end
 
-        it 'prints "Default location from [DATE] to present set to" output message' do
+        focus; it 'prints "Default location from [DATE] to present set to" output message' do
           assert_default_location_output('Default location from 1999-01-01 to present set to: "Paris"')
         end
       end
@@ -154,8 +154,49 @@ FILE
 FILE
         end
 
-        it 'prints "Default location from [DATE] to present already set to" output message' do
+        focus; it 'prints "Default location from [DATE] to present already set to" output message' do
           assert_default_location_output('Default location from 1980-01-01 to present already set to: "Paris"')
+        end
+      end
+
+      describe 'when default location is different to preceding default location' do
+        let(:content) do
+          <<-FILE
+### Activities:
+- 2016-01-01: Visited my favourite cafe.
+- 1980-01-01: Flew to _Berlin_.
+
+### Notes:
+
+### Friends:
+
+### Locations:
+- Berlin
+FILE
+        end
+
+        focus; it 'prints "Default location from [DATE] to present set to" output message' do
+          assert_default_location_output('Default location from 1999-01-01 to present set to: "Paris"')
+        end
+      end
+
+      describe "when default location precedes the same default location" do
+        let(:content) do
+          <<-FILE
+### Activities:
+- 2016-01-01: Flew to _Paris_.
+
+### Notes:
+
+### Friends:
+
+### Locations:
+- Paris
+FILE
+        end
+
+        focus; it 'prints "Default location from [DATE] to present set to" output message' do
+          assert_default_location_output('Default location from 1999-01-01 to present set to: "Paris"')
         end
       end
 
@@ -174,12 +215,12 @@ FILE
 FILE
         end
 
-        it 'prints "Default location from [DATE] to [DATE] set to" output message' do
+        focus; it 'prints "Default location from [DATE] to [DATE] set to" output message' do
           assert_default_location_output('Default location from 1999-01-01 to 2016-01-01 set to: "Paris"')
         end
       end
 
-      describe "when default location precdes a different default location and proceeds the same default location" do
+      describe "when default location precedes a different default location and proceeds the same default location" do
         let(:content) do
           <<-FILE
 ### Activities:
@@ -195,7 +236,7 @@ FILE
 FILE
         end
 
-        it 'prints "Default location from [DATE] to [DATE] already set to" output message' do
+        focus; it 'prints "Default location from [DATE] to [DATE] already set to" output message' do
           assert_default_location_output('Default location from 1980-01-01 to 2016-01-01 already set to: "Paris"')
         end
       end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -51,5 +51,39 @@ FILE
     end
   end
 
+  describe "adding default location" do
+    subject { run_cmd("add activity 2017-01-01: Moved to Paris") }
+    let(:content) do
+      <<-FILE
+### Activities:
+- 2016-01-01: #{activity}.
+
+### Notes:
+
+### Friends:
+
+### Locations:
+- Paris
+FILE
+    end
+
+    describe "when default location has not been set before" do
+      let(:activity) { "Had dinner in _Paris_" }
+
+      it 'prints "Default location added" output message' do
+        value(subject[:stdout].include? 'Default location set to: "Paris"').must_equal true 
+      end
+    end
+
+    describe "when default location has already been set" do
+      let(:activity) { "Went to _Paris_ for a holiday" }
+
+      it 'does not print "Default location added" output message' do
+        value(subject[:stdout].include? 'Default location set to: "Paris"').must_equal false 
+      end
+    end    
+
+  end
+
   parsing_specs(event: :activity)
 end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -91,7 +91,7 @@ FILE
 FILE
     end
 
-      focus; it 'prints "Default location set to" output message' do
+      it 'prints "Default location set to" output message' do
         value(subject[:stdout].must_include('Default location set to: "Paris"'))
       end
     end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -124,6 +124,7 @@ FILE
         end
       end
     end
+
     describe 'when it is not the latest activity' do
       subject { run_cmd("add activity 1999-01-01: Moved to _Paris_") }
 
@@ -173,6 +174,33 @@ FILE
         value(stdout_for_testing.must_include('Default location from 1980-01-01 to present already set to: "Paris"'))
       end
 
+      end
+
+      describe 'when default location precedes a different default location' do
+      let(:content) do
+      <<-FILE
+### Activities:
+- 2016-01-01: Flew to _Berlin_.
+
+### Notes:
+
+### Friends:
+
+### Locations:
+- Berlin
+FILE
+      end
+
+      focus;it 'prints "Default location from [DATE] to [DATE] set to" output message' do
+        stdout_for_testing = strip_out_activity(subject[:stdout])
+
+        stdout_for_testing.size.must_equal 1
+        value(stdout_for_testing.must_include('Default location from 1999-01-01 to 2016-01-01 set to: "Paris"'))
+      end
+
+      end
+
+      describe 'when default location precdes a different default location and proceeds the same default location' do
       end
     end
   end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -56,8 +56,8 @@ FILE
       subject { run_cmd("add activity Moved to _Paris_") }
 
       describe "when a default location has never been set before" do
-      let(:content) do
-      <<-FILE
+        let(:content) do
+          <<-FILE
 ### Activities:
 - 2016-01-01: Had dinner in _Berlin_.
 
@@ -68,19 +68,19 @@ FILE
 ### Locations:
 - Berlin
 FILE
-      end
+        end
 
-        focus; it 'prints "Default location set to" output message' do
+        it 'prints "Default location set to" output message' do
           stdout_for_testing = strip_out_activity(subject[:stdout])
-          
+
           stdout_for_testing.size.must_equal 1
           value(stdout_for_testing.must_include('Default location set to: "Paris"'))
         end
       end
 
       describe "when current default location is different to the last default location" do
-      let(:content) do
-      <<-FILE
+        let(:content) do
+          <<-FILE
 ### Activities:
 - 2016-01-01: Moved to _Berlin_.
 
@@ -91,19 +91,19 @@ FILE
 ### Locations:
 - Berlin
 FILE
-      end
+        end
 
-        focus; it 'prints "Default location set to" output message' do
+        it 'prints "Default location set to" output message' do
           stdout_for_testing = strip_out_activity(subject[:stdout])
-          
+
           stdout_for_testing.size.must_equal 1
           value(stdout_for_testing.must_include('Default location set to: "Paris"'))
         end
       end
 
       describe "when current default location is the same as the last default location" do
-      let(:content) do
-      <<-FILE
+        let(:content) do
+          <<-FILE
 ### Activities:
 - 2016-01-01: Flew to _Paris_.
 
@@ -114,9 +114,9 @@ FILE
 ### Locations:
 - Paris
 FILE
-      end
+        end
 
-        focus; it 'prints "Default location already set to" output message' do
+        it 'prints "Default location already set to" output message' do
           stdout_for_testing = strip_out_activity(subject[:stdout])
 
           stdout_for_testing.size.must_equal 1
@@ -125,12 +125,12 @@ FILE
       end
     end
 
-    describe 'when it is not the latest activity' do
+    describe "when it is not the latest activity" do
       subject { run_cmd("add activity 1999-01-01: Moved to _Paris_") }
 
-      describe 'when a default location has never been set before' do
-      let(:content) do
-      <<-FILE
+      describe "when a default location has never been set before" do
+        let(:content) do
+          <<-FILE
 ### Activities:
 - 2016-01-01: Visited my favourite cafe.
 
@@ -140,20 +140,19 @@ FILE
 
 ### Locations:
 FILE
-      end
+        end
 
-        focus;it 'prints "Default location from [DATE] to present set to" output message' do
+        it 'prints "Default location from [DATE] to present set to" output message' do
           stdout_for_testing = strip_out_activity(subject[:stdout])
 
           stdout_for_testing.size.must_equal 1
           value(stdout_for_testing.must_include('Default location from 1999-01-01 to present set to: "Paris"'))
         end
-
       end
 
-      describe 'when default location is the same as the preceding default location' do
-      let(:content) do
-      <<-FILE
+      describe "when default location is the same as the preceding default location" do
+        let(:content) do
+          <<-FILE
 ### Activities:
 - 2016-01-01: Visited my favourite cafe.
 - 1980-01-01: Flew to _Paris_.
@@ -165,20 +164,19 @@ FILE
 ### Locations:
 - Paris
 FILE
+        end
+
+        it 'prints "Default location from [DATE] to present already set to" output message' do
+          stdout_for_testing = strip_out_activity(subject[:stdout])
+
+          stdout_for_testing.size.must_equal 1
+          value(stdout_for_testing.must_include('Default location from 1980-01-01 to present already set to: "Paris"'))
+        end
       end
 
-      focus;it 'prints "Default location from [DATE] to present already set to" output message' do
-        stdout_for_testing = strip_out_activity(subject[:stdout])
-
-        stdout_for_testing.size.must_equal 1
-        value(stdout_for_testing.must_include('Default location from 1980-01-01 to present already set to: "Paris"'))
-      end
-
-      end
-
-      describe 'when default location precedes a different default location' do
-      let(:content) do
-      <<-FILE
+      describe "when default location precedes a different default location" do
+        let(:content) do
+          <<-FILE
 ### Activities:
 - 2016-01-01: Flew to _Berlin_.
 
@@ -189,20 +187,19 @@ FILE
 ### Locations:
 - Berlin
 FILE
+        end
+
+        it 'prints "Default location from [DATE] to [DATE] set to" output message' do
+          stdout_for_testing = strip_out_activity(subject[:stdout])
+
+          stdout_for_testing.size.must_equal 1
+          value(stdout_for_testing.must_include('Default location from 1999-01-01 to 2016-01-01 set to: "Paris"'))
+        end
       end
 
-      focus;it 'prints "Default location from [DATE] to [DATE] set to" output message' do
-        stdout_for_testing = strip_out_activity(subject[:stdout])
-
-        stdout_for_testing.size.must_equal 1
-        value(stdout_for_testing.must_include('Default location from 1999-01-01 to 2016-01-01 set to: "Paris"'))
-      end
-
-      end
-
-      describe 'when default location precdes a different default location and proceeds the same default location' do
-      let(:content) do
-      <<-FILE
+      describe "when default location precdes a different default location and proceeds the same default location" do
+        let(:content) do
+          <<-FILE
 ### Activities:
 - 2016-01-01: Flew to _Berlin_.
 - 1980-01-01: Flew to _Paris_.
@@ -214,24 +211,24 @@ FILE
 ### Locations:
 - Berlin
 FILE
-      end
+        end
 
-      focus;it 'prints "Default location from [DATE] to [DATE] already set to" output message' do
-        stdout_for_testing = strip_out_activity(subject[:stdout])
+        it 'prints "Default location from [DATE] to [DATE] already set to" output message' do
+          stdout_for_testing = strip_out_activity(subject[:stdout])
 
-        stdout_for_testing.size.must_equal 1
-        value(stdout_for_testing.must_include('Default location from 1980-01-01 to 2016-01-01 already set to: "Paris"'))
-      end
-
+          stdout_for_testing.size.must_equal 1
+          value(stdout_for_testing.must_include('Default location from 1980-01-01 to 2016-01-01 already set to: "Paris"'))
+        end
       end
     end
   end
 
   parsing_specs(event: :activity)
 
-private
+  private
+
   def strip_out_activity(output)
     lines = output.split("\n")
-    lines.reject {|line| !line.include?("Default")}
+    lines.select { |line| line.include?("Default") }
   end
 end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -201,6 +201,28 @@ FILE
       end
 
       describe 'when default location precdes a different default location and proceeds the same default location' do
+      let(:content) do
+      <<-FILE
+### Activities:
+- 2016-01-01: Flew to _Berlin_.
+- 1980-01-01: Flew to _Paris_.
+
+### Notes:
+
+### Friends:
+
+### Locations:
+- Berlin
+FILE
+      end
+
+      focus;it 'prints "Default location from [DATE] to [DATE] already set to" output message' do
+        stdout_for_testing = strip_out_activity(subject[:stdout])
+
+        stdout_for_testing.size.must_equal 1
+        value(stdout_for_testing.must_include('Default location from 1980-01-01 to 2016-01-01 already set to: "Paris"'))
+      end
+
       end
     end
   end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -52,10 +52,11 @@ FILE
   end
 
   describe "adding default location" do
-    subject { run_cmd("add activity 2017-01-01: Moved to _Paris_") }
+    describe "when it is the lastest activity" do
+      subject { run_cmd("add activity Moved to _Paris_") }
 
-    describe "when a default location has never been set before" do
-    let(:content) do
+      describe "when a default location has never been set before" do
+      let(:content) do
       <<-FILE
 ### Activities:
 - 2016-01-01: Had dinner in _Berlin_.
@@ -67,22 +68,21 @@ FILE
 ### Locations:
 - Berlin
 FILE
-    end
-
-      focus; it 'prints "Default location set to" output message' do
-        stdout_for_testing = strip_out_activity(subject[:stdout])
-        
-        stdout_for_testing.size.must_equal 1
-        value(stdout_for_testing.must_include('Default location set to: "Paris"'))
       end
-    end
 
-    describe "when current default location was already set before the last default location" do
-    let(:content) do
+        focus; it 'prints "Default location set to" output message' do
+          stdout_for_testing = strip_out_activity(subject[:stdout])
+          
+          stdout_for_testing.size.must_equal 1
+          value(stdout_for_testing.must_include('Default location set to: "Paris"'))
+        end
+      end
+
+      describe "when current default location is different to the last default location" do
+      let(:content) do
       <<-FILE
 ### Activities:
 - 2016-01-01: Moved to _Berlin_.
-- 2015-01-01: Flew to _Paris_.
 
 ### Notes:
 
@@ -90,20 +90,19 @@ FILE
 
 ### Locations:
 - Berlin
-- Paris
 FILE
-    end
-
-      focus; it 'prints "Default location set to" output message' do
-        stdout_for_testing = strip_out_activity(subject[:stdout])
-        
-        stdout_for_testing.size.must_equal 1
-        value(stdout_for_testing.must_include('Default location set to: "Paris"'))
       end
-    end
 
-    describe "when current default location is the same as the last default location" do
-    let(:content) do
+        focus; it 'prints "Default location set to" output message' do
+          stdout_for_testing = strip_out_activity(subject[:stdout])
+          
+          stdout_for_testing.size.must_equal 1
+          value(stdout_for_testing.must_include('Default location set to: "Paris"'))
+        end
+      end
+
+      describe "when current default location is the same as the last default location" do
+      let(:content) do
       <<-FILE
 ### Activities:
 - 2016-01-01: Flew to _Paris_.
@@ -115,13 +114,40 @@ FILE
 ### Locations:
 - Paris
 FILE
+      end
+
+        focus; it 'prints "Default location already set to" output message' do
+          stdout_for_testing = strip_out_activity(subject[:stdout])
+
+          stdout_for_testing.size.must_equal 1
+          value(stdout_for_testing.must_include('Default location already set to: "Paris"'))
+        end
+      end
     end
+    describe 'when it is not the latest activity' do
+      subject { run_cmd("add activity 1999-01-01: Moved to _Paris_") }
 
-      focus; it 'prints "Default location already set to" output message' do
-        stdout_for_testing = strip_out_activity(subject[:stdout])
+      describe 'when a default location has never been set before' do
+      let(:content) do
+      <<-FILE
+### Activities:
+- 2016-01-01: Visited my favourite cafe.
 
-        stdout_for_testing.size.must_equal 1
-        value(stdout_for_testing.must_include('Default location already set to: "Paris"'))
+### Notes:
+
+### Friends:
+
+### Locations:
+FILE
+      end
+
+        focus;it 'prints "Default location from [DATE] to present set to" output message' do
+          stdout_for_testing = strip_out_activity(subject[:stdout])
+
+          stdout_for_testing.size.must_equal 1
+          value(stdout_for_testing.must_include('Default location from 1999-01-01 to present set to: "Paris"'))
+        end
+
       end
     end
   end

--- a/test/commands/add/activity_spec.rb
+++ b/test/commands/add/activity_spec.rb
@@ -52,11 +52,33 @@ FILE
   end
 
   describe "adding default location" do
-    subject { run_cmd("add activity 2017-01-01: Moved to Paris") }
+    subject { run_cmd("add activity 2017-01-01: Moved to _Paris_") }
+
+    describe "when default location has not been set before" do
     let(:content) do
       <<-FILE
 ### Activities:
-- 2016-01-01: #{activity}.
+- 2016-01-01: Had dinner in _Berlin_.
+
+### Notes:
+
+### Friends:
+
+### Locations:
+- Berlin
+FILE
+    end
+
+      it 'prints "Default location set to" output message' do
+        value(subject[:stdout].must_include('Default location set to: "Paris"'))
+      end
+    end
+
+    describe "when default location has already been set" do
+    let(:content) do
+      <<-FILE
+### Activities:
+- 2016-01-01: Flew to _Paris_.
 
 ### Notes:
 
@@ -67,19 +89,8 @@ FILE
 FILE
     end
 
-    describe "when default location has not been set before" do
-      let(:activity) { "Had dinner in _Paris_" }
-
-      it 'prints "Default location set to" output message' do
-        value(subject[:stdout].must_include('Default location set to: "Paris"'))
-      end
-    end
-
-    describe "when default location has already been set" do
-      let(:activity) { "Went to _Paris_ for a holiday" }
-
-      it 'does not print "Default location added" output message' do
-        value(subject[:stdout].wont_include('Default location set to: "Paris"'))
+      focus; it 'prints "Default location already set to" output message' do
+        value(subject[:stdout].must_include('Default location already set to: "Paris"'))
       end
     end
   end

--- a/test/commands/edit_spec.rb
+++ b/test/commands/edit_spec.rb
@@ -78,7 +78,7 @@ Not cleaning file: "#{filename}" ("exit 1 #" did not exit successfully)
       <<-EXPECTED_CONTENT
 ### Activities:
 - 2018-02-06: @science:indoors:agronomy-with-hydroponics: **Norman Borlaug** and **George Washington Carver** scored a tour of _Atlantis_' hydroponics gardens through wetplants@example.org and they took me along.
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-12-16: Okay, yep, I definitely just saw **Bigfoot** in the _Mysterious Mountains_!

--- a/test/commands/edit_spec.rb
+++ b/test/commands/edit_spec.rb
@@ -78,7 +78,7 @@ Not cleaning file: "#{filename}" ("exit 1 #" did not exit successfully)
       <<-EXPECTED_CONTENT
 ### Activities:
 - 2018-02-06: @science:indoors:agronomy-with-hydroponics: **Norman Borlaug** and **George Washington Carver** scored a tour of _Atlantis_' hydroponics gardens through wetplants@example.org and they took me along.
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to Marie's Diner. George had to cancel at the last minute. @food
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-12-16: Okay, yep, I definitely just saw **Bigfoot** in the _Mysterious Mountains_!
@@ -101,7 +101,6 @@ Not cleaning file: "#{filename}" ("exit 1 #" did not exit successfully)
 
 ### Locations:
 - Atlantis
-- Marie's Diner
 - Mysterious Mountains
 - Paris
       EXPECTED_CONTENT

--- a/test/commands/edit_spec.rb
+++ b/test/commands/edit_spec.rb
@@ -78,7 +78,7 @@ Not cleaning file: "#{filename}" ("exit 1 #" did not exit successfully)
       <<-EXPECTED_CONTENT
 ### Activities:
 - 2018-02-06: @science:indoors:agronomy-with-hydroponics: **Norman Borlaug** and **George Washington Carver** scored a tour of _Atlantis_' hydroponics gardens through wetplants@example.org and they took me along.
-- 2015-11-01: **Grace Hopper** and I went to Marie's Diner. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-12-16: Okay, yep, I definitely just saw **Bigfoot** in the _Mysterious Mountains_!
@@ -101,6 +101,7 @@ Not cleaning file: "#{filename}" ("exit 1 #" did not exit successfully)
 
 ### Locations:
 - Atlantis
+- Marie's Diner
 - Mysterious Mountains
 - Paris
       EXPECTED_CONTENT

--- a/test/commands/edit_spec.rb
+++ b/test/commands/edit_spec.rb
@@ -78,7 +78,7 @@ Not cleaning file: "#{filename}" ("exit 1 #" did not exit successfully)
       <<-EXPECTED_CONTENT
 ### Activities:
 - 2018-02-06: @science:indoors:agronomy-with-hydroponics: **Norman Borlaug** and **George Washington Carver** scored a tour of _Atlantis_' hydroponics gardens through wetplants@example.org and they took me along.
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
+- 2015-11-01: **Grace Hopper** and I went to _Martha's Vineyard_. George had to cancel at the last minute.
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-12-16: Okay, yep, I definitely just saw **Bigfoot** in the _Mysterious Mountains_!
@@ -101,7 +101,7 @@ Not cleaning file: "#{filename}" ("exit 1 #" did not exit successfully)
 
 ### Locations:
 - Atlantis
-- Marie's Diner
+- Martha's Vineyard
 - Mysterious Mountains
 - Paris
       EXPECTED_CONTENT

--- a/test/commands/graph_spec.rb
+++ b/test/commands/graph_spec.rb
@@ -27,7 +27,7 @@ clean_describe "graph" do
     let(:content) do
       <<-FILE
 ### Activities:
-- 2015-11-01: **Grace Hopper** and I went to Marie's Diner. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
 - 2015-01-14: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2015-01-06: Did some other things in _Paris_.
 - 2015-01-06: Did even more things in _Paris_.
@@ -42,6 +42,7 @@ clean_describe "graph" do
 
 ### Locations:
 - Atlantis
+- Marie's Diner
 - Paris
       FILE
     end

--- a/test/commands/graph_spec.rb
+++ b/test/commands/graph_spec.rb
@@ -27,7 +27,7 @@ clean_describe "graph" do
     let(:content) do
       <<-FILE
 ### Activities:
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
 - 2015-01-14: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2015-01-06: Did some other things in _Paris_.
 - 2015-01-06: Did even more things in _Paris_.
@@ -273,7 +273,7 @@ Nov 2014 |∙|
 
       it "matches tag case-insensitively and scales the graph" do
         stdout_only <<-OUTPUT
-Nov 2015 |█████∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙|
+Nov 2015 |∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙|
 Oct 2015 |∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙|
 Sep 2015 |∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙|
 Aug 2015 |∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙|
@@ -291,10 +291,10 @@ Nov 2014 |∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙|
 
       describe "--unscaled" do
         let(:unscaled) { true }
-
+        
         it "matches tag case-insensitively and does not scale graph" do
           stdout_only <<-OUTPUT
-Nov 2015 |█
+Nov 2015 |∙|
 Oct 2015 |
 Sep 2015 |
 Aug 2015 |

--- a/test/commands/graph_spec.rb
+++ b/test/commands/graph_spec.rb
@@ -291,7 +291,7 @@ Nov 2014 |∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙|
 
       describe "--unscaled" do
         let(:unscaled) { true }
-        
+
         it "matches tag case-insensitively and does not scale graph" do
           stdout_only <<-OUTPUT
 Nov 2015 |∙|

--- a/test/commands/graph_spec.rb
+++ b/test/commands/graph_spec.rb
@@ -27,7 +27,7 @@ clean_describe "graph" do
     let(:content) do
       <<-FILE
 ### Activities:
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
+- 2015-11-01: **Grace Hopper** and I went to _Martha's Vineyard_. George had to cancel at the last minute.
 - 2015-01-14: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2015-01-06: Did some other things in _Paris_.
 - 2015-01-06: Did even more things in _Paris_.
@@ -42,7 +42,7 @@ clean_describe "graph" do
 
 ### Locations:
 - Atlantis
-- Marie's Diner
+- Martha's Vineyard
 - Paris
       FILE
     end

--- a/test/commands/graph_spec.rb
+++ b/test/commands/graph_spec.rb
@@ -27,7 +27,7 @@ clean_describe "graph" do
     let(:content) do
       <<-FILE
 ### Activities:
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to Marie's Diner. George had to cancel at the last minute. @food
 - 2015-01-14: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2015-01-06: Did some other things in _Paris_.
 - 2015-01-06: Did even more things in _Paris_.
@@ -42,7 +42,6 @@ clean_describe "graph" do
 
 ### Locations:
 - Atlantis
-- Marie's Diner
 - Paris
       FILE
     end

--- a/test/commands/list/activities_spec.rb
+++ b/test/commands/list/activities_spec.rb
@@ -193,9 +193,9 @@ FILE
 
       it "lists activities on and after the specified date" do
         stdout_only <<-OUTPUT
-2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
-2015-11-01: Grace Hopper and I went to Martha's Vineyard. George had to cancel at the last minute.
 2018-02-06: @science:indoors:agronomy-with-hydroponics: Norman Borlaug and George Washington Carver scored a tour of Atlantis' hydroponics gardens through wetplants@example.org and they took me along.
+2015-11-01: Grace Hopper and I went to Martha's Vineyard. George had to cancel at the last minute.
+2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
         OUTPUT
       end
     end
@@ -206,8 +206,8 @@ FILE
       it "lists activities before and on the specified date" do
         stdout_only <<-OUTPUT
 2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
-2014-11-15: Talked to George Washington Carver on the phone for an hour.
 2014-12-31: Celebrated the new year in Paris with Marie Curie. @partying
+2014-11-15: Talked to George Washington Carver on the phone for an hour.
         OUTPUT
       end
     end

--- a/test/commands/list/activities_spec.rb
+++ b/test/commands/list/activities_spec.rb
@@ -55,15 +55,16 @@ clean_describe "list activities" do
 
       describe "when implicit location is set" do
         let(:location_name) { "atlantis" }
-        let(:content) do
-          <<-FILE
+        describe 'when activities are in order' do
+          let(:content) do
+            <<-FILE
 ### Activities:
-- 2015-01-30: Went to a museum with **George Washington Carver**.
-- 2015-01-29: Moved to _Paris_.
-- 2015-01-01: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
-- 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying @food
-- 2014-12-30: Went to _Atlantis_.
-- 2014-12-29: Talked to **George Washington Carver** on the phone for an hour.
+- 2000-01-06: Went to a museum with **George Washington Carver**.
+- 2000-01-05: Moved to _Paris_.
+- 2000-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
+- 2000-01-03: Celebrated my birthday in _Paris_ with **Marie Curie**. @partying @food
+- 2000-01-02: Went to _Atlantis_.
+- 2000-01-01: Talked to **George Washington Carver** on the phone for an hour.
 
 ### Friends:
 - George Washington Carver
@@ -73,14 +74,44 @@ clean_describe "list activities" do
 ### Locations:
 - Atlantis
 - Paris
-          FILE
-        end
+            FILE
+          end
 
-        it "matches location case-insensitively" do
-          stdout_only <<-OUTPUT
-2015-01-01: Got lunch with Grace Hopper and George Washington Carver. @food
-2014-12-30: Went to Atlantis.
-        OUTPUT
+          it "matches location case-insensitively" do
+            stdout_only <<-OUTPUT
+2000-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
+2000-01-02: Went to Atlantis.
+          OUTPUT
+          end
+        end
+        describe 'when activities are not in order' do
+          let(:content) do
+            <<-FILE
+### Activities:
+- 2000-01-06: Went to a museum with **George Washington Carver**.
+- 2000-01-02: Went to _Atlantis_.
+- 2000-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
+- 2000-01-03: Celebrated my birthday in _Paris_ with **Marie Curie**. @partying @food
+- 2000-01-05: Moved to _Paris_.
+- 2000-01-01: Talked to **George Washington Carver** on the phone for an hour.
+
+### Friends:
+- George Washington Carver
+- Marie Curie [Atlantis] @science
+- Grace Hopper (a.k.a. The Admiral a.k.a. Amazing Grace) [Paris] @navy @science
+
+### Locations:
+- Atlantis
+- Paris
+            FILE
+          end
+
+          focus;it "matches location case-insensitively" do
+            stdout_only <<-OUTPUT
+2000-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
+2000-01-02: Went to Atlantis.
+          OUTPUT
+          end
         end
       end
     end

--- a/test/commands/list/activities_spec.rb
+++ b/test/commands/list/activities_spec.rb
@@ -29,7 +29,7 @@ clean_describe "list activities" do
     it "lists activities in file order" do
       stdout_only <<-OUTPUT
 2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
-2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute. @food
+2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute.
 2018-02-06: @science:indoors:agronomy-with-hydroponics: Norman Borlaug and George Washington Carver scored a tour of Atlantis' hydroponics gardens through wetplants@example.org and they took me along.
 2014-11-15: Talked to George Washington Carver on the phone for an hour.
 2014-12-31: Celebrated the new year in Paris with Marie Curie. @partying
@@ -127,7 +127,6 @@ clean_describe "list activities" do
       it "matches tag case-insensitively" do
         stdout_only <<-OUTPUT
 2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
-2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute. @food
         OUTPUT
       end
 
@@ -139,7 +138,7 @@ clean_describe "list activities" do
           <<-FILE
 ### Activities:
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying @food
 
@@ -164,7 +163,7 @@ FILE
       it "lists activities on and after the specified date" do
         stdout_only <<-OUTPUT
 2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
-2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute. @food
+2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute.
 2018-02-06: @science:indoors:agronomy-with-hydroponics: Norman Borlaug and George Washington Carver scored a tour of Atlantis' hydroponics gardens through wetplants@example.org and they took me along.
         OUTPUT
       end

--- a/test/commands/list/activities_spec.rb
+++ b/test/commands/list/activities_spec.rb
@@ -59,10 +59,10 @@ clean_describe "list activities" do
           <<-FILE
 ### Activities:
 - 2015-01-30: Went to a museum with **George Washington Carver**.
-- 2015-01-29: moved to _Paris_.
+- 2015-01-29: Moved to _Paris_.
 - 2015-01-01: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying @food
-- 2014-12-30: Moved to _Atlantis_.
+- 2014-12-30: Went to _Atlantis_.
 - 2014-12-29: Talked to **George Washington Carver** on the phone for an hour.
 
 ### Friends:
@@ -79,7 +79,7 @@ clean_describe "list activities" do
         it "matches location case-insensitively" do
           stdout_only <<-OUTPUT
 2015-01-01: Got lunch with Grace Hopper and George Washington Carver. @food
-2014-12-30: Moved to Atlantis.
+2014-12-30: Went to Atlantis.
         OUTPUT
         end
       end

--- a/test/commands/list/activities_spec.rb
+++ b/test/commands/list/activities_spec.rb
@@ -55,7 +55,7 @@ clean_describe "list activities" do
 
       describe "when implicit location is set" do
         let(:location_name) { "atlantis" }
-        describe 'when activities are in order' do
+        describe "when activities are in order" do
           let(:content) do
             <<-FILE
 ### Activities:
@@ -84,7 +84,7 @@ clean_describe "list activities" do
           OUTPUT
           end
         end
-        describe 'when activities are not in order' do
+        describe "when activities are not in order" do
           let(:content) do
             <<-FILE
 ### Activities:

--- a/test/commands/list/activities_spec.rb
+++ b/test/commands/list/activities_spec.rb
@@ -106,7 +106,7 @@ clean_describe "list activities" do
             FILE
           end
 
-          focus;it "matches location case-insensitively" do
+          it "matches location case-insensitively" do
             stdout_only <<-OUTPUT
 2000-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
 2000-01-02: Went to Atlantis.

--- a/test/commands/list/activities_spec.rb
+++ b/test/commands/list/activities_spec.rb
@@ -29,7 +29,7 @@ clean_describe "list activities" do
     it "lists activities in file order" do
       stdout_only <<-OUTPUT
 2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
-2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute.
+2015-11-01: Grace Hopper and I went to Martha's Vineyard. George had to cancel at the last minute.
 2018-02-06: @science:indoors:agronomy-with-hydroponics: Norman Borlaug and George Washington Carver scored a tour of Atlantis' hydroponics gardens through wetplants@example.org and they took me along.
 2014-11-15: Talked to George Washington Carver on the phone for an hour.
 2014-12-31: Celebrated the new year in Paris with Marie Curie. @partying
@@ -138,7 +138,7 @@ clean_describe "list activities" do
           <<-FILE
 ### Activities:
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
+- 2015-11-01: **Grace Hopper** and I went to _Martha's Vineyard_. George had to cancel at the last minute.
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying @food
 
@@ -163,7 +163,7 @@ FILE
       it "lists activities on and after the specified date" do
         stdout_only <<-OUTPUT
 2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
-2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute.
+2015-11-01: Grace Hopper and I went to Martha's Vineyard. George had to cancel at the last minute.
 2018-02-06: @science:indoors:agronomy-with-hydroponics: Norman Borlaug and George Washington Carver scored a tour of Atlantis' hydroponics gardens through wetplants@example.org and they took me along.
         OUTPUT
       end

--- a/test/commands/list/activities_spec.rb
+++ b/test/commands/list/activities_spec.rb
@@ -139,7 +139,7 @@ clean_describe "list activities" do
           <<-FILE
 ### Activities:
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
-- 2015-11-01: **Grace Hopper** and I went to Marie's Diner. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying @food
 

--- a/test/commands/list/activities_spec.rb
+++ b/test/commands/list/activities_spec.rb
@@ -139,7 +139,7 @@ clean_describe "list activities" do
           <<-FILE
 ### Activities:
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to Marie's Diner. George had to cancel at the last minute. @food
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying @food
 

--- a/test/commands/list/activities_spec.rb
+++ b/test/commands/list/activities_spec.rb
@@ -26,13 +26,13 @@ clean_describe "list activities" do
     # only reads from the (usually-sorted) file.
     let(:content) { SCRAMBLED_CONTENT }
 
-    it "lists activities in file order" do
+    it "lists activities in sorted order" do
       stdout_only <<-OUTPUT
-2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
-2015-11-01: Grace Hopper and I went to Martha's Vineyard. George had to cancel at the last minute.
 2018-02-06: @science:indoors:agronomy-with-hydroponics: Norman Borlaug and George Washington Carver scored a tour of Atlantis' hydroponics gardens through wetplants@example.org and they took me along.
-2014-11-15: Talked to George Washington Carver on the phone for an hour.
+2015-11-01: Grace Hopper and I went to Martha's Vineyard. George had to cancel at the last minute.
+2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
 2014-12-31: Celebrated the new year in Paris with Marie Curie. @partying
+2014-11-15: Talked to George Washington Carver on the phone for an hour.
       OUTPUT
     end
 
@@ -191,7 +191,7 @@ FILE
     describe "--since" do
       subject { run_cmd("list activities --since 'January 4th 2015'") }
 
-      it "lists activities on and after the specified date" do
+      it "lists activities on and after the specified date in order" do
         stdout_only <<-OUTPUT
 2018-02-06: @science:indoors:agronomy-with-hydroponics: Norman Borlaug and George Washington Carver scored a tour of Atlantis' hydroponics gardens through wetplants@example.org and they took me along.
 2015-11-01: Grace Hopper and I went to Martha's Vineyard. George had to cancel at the last minute.
@@ -203,7 +203,7 @@ FILE
     describe "--until" do
       subject { run_cmd("list activities --until 'January 4th 2015'") }
 
-      it "lists activities before and on the specified date" do
+      it "lists activities before and on the specified date in order" do
         stdout_only <<-OUTPUT
 2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
 2014-12-31: Celebrated the new year in Paris with Marie Curie. @partying

--- a/test/commands/list/favorite/friends_spec.rb
+++ b/test/commands/list/favorite/friends_spec.rb
@@ -26,7 +26,7 @@ clean_describe "list favorite friends" do
       <<-FILE
 ### Activities:
 - 2017-01-01: Did some math with **Grace Hopper**.
-- 2015-11-01: **Grace Hopper** and I went to Marie's Diner. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.

--- a/test/commands/list/favorite/friends_spec.rb
+++ b/test/commands/list/favorite/friends_spec.rb
@@ -26,7 +26,7 @@ clean_describe "list favorite friends" do
       <<-FILE
 ### Activities:
 - 2017-01-01: Did some math with **Grace Hopper**.
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
+- 2015-11-01: **Grace Hopper** and I went to _Martha's Vineyard_. George had to cancel at the last minute.
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.

--- a/test/commands/list/favorite/friends_spec.rb
+++ b/test/commands/list/favorite/friends_spec.rb
@@ -26,7 +26,7 @@ clean_describe "list favorite friends" do
       <<-FILE
 ### Activities:
 - 2017-01-01: Did some math with **Grace Hopper**.
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.

--- a/test/commands/list/favorite/friends_spec.rb
+++ b/test/commands/list/favorite/friends_spec.rb
@@ -26,7 +26,7 @@ clean_describe "list favorite friends" do
       <<-FILE
 ### Activities:
 - 2017-01-01: Did some math with **Grace Hopper**.
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to Marie's Diner. George had to cancel at the last minute. @food
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.

--- a/test/commands/list/favorite/locations_spec.rb
+++ b/test/commands/list/favorite/locations_spec.rb
@@ -25,8 +25,8 @@ clean_describe "list favorite locations" do
     let(:content) do
       <<-FILE
 ### Activities:
-- 2017-01-01: **Grace Hopper** and I went to _Marie's Diner_ for breakfast.
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2017-01-01: **Grace Hopper** and I went to _London_.
+- 2015-11-01: **Grace Hopper** and I went to _London_ and ate fish and chips. George had to cancel at the last minute. @food
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
@@ -38,7 +38,7 @@ clean_describe "list favorite locations" do
 
 ### Locations:
 - Atlantis
-- Marie's Diner
+- London
 - Paris
 FILE
     end
@@ -46,9 +46,9 @@ FILE
     it "lists locations in order of decreasing activity" do
       stdout_only <<-OUTPUT
 Your favorite locations:
-1. Marie's Diner (2 activities)
-2. Paris         (1)
-3. Atlantis      (0)
+1. London   (2 activities)
+2. Paris    (1)
+3. Atlantis (0)
       OUTPUT
     end
 

--- a/test/commands/list/favorite/locations_spec.rb
+++ b/test/commands/list/favorite/locations_spec.rb
@@ -25,8 +25,8 @@ clean_describe "list favorite locations" do
     let(:content) do
       <<-FILE
 ### Activities:
-- 2017-01-01: **Grace Hopper** and I went to _London_.
-- 2015-11-01: **Grace Hopper** and I went to _London_ and ate fish and chips. George had to cancel at the last minute. @food
+- 2017-01-01: **Grace Hopper** and I went to _Marie's Diner_ for breakfast.
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
@@ -38,7 +38,7 @@ clean_describe "list favorite locations" do
 
 ### Locations:
 - Atlantis
-- London
+- Marie's Diner
 - Paris
 FILE
     end
@@ -46,9 +46,9 @@ FILE
     it "lists locations in order of decreasing activity" do
       stdout_only <<-OUTPUT
 Your favorite locations:
-1. London   (2 activities)
-2. Paris    (1)
-3. Atlantis (0)
+1. Marie's Diner (2 activities)
+2. Paris         (1)
+3. Atlantis      (0)
       OUTPUT
     end
 

--- a/test/commands/list/favorite/locations_spec.rb
+++ b/test/commands/list/favorite/locations_spec.rb
@@ -25,8 +25,8 @@ clean_describe "list favorite locations" do
     let(:content) do
       <<-FILE
 ### Activities:
-- 2017-01-01: **Grace Hopper** and I went to _Marie's Diner_ for breakfast.
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
+- 2017-01-01: **Grace Hopper** and I went to _Martha's Vineyard_ for breakfast.
+- 2015-11-01: **Grace Hopper** and I went to _Martha's Vineyard_. George had to cancel at the last minute.
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
@@ -38,7 +38,7 @@ clean_describe "list favorite locations" do
 
 ### Locations:
 - Atlantis
-- Marie's Diner
+- Martha's Vineyard
 - Paris
 FILE
     end
@@ -46,9 +46,9 @@ FILE
     it "lists locations in order of decreasing activity" do
       stdout_only <<-OUTPUT
 Your favorite locations:
-1. Marie's Diner (2 activities)
-2. Paris         (1)
-3. Atlantis      (0)
+1. Martha's Vineyard (2 activities)
+2. Paris             (1)
+3. Atlantis          (0)
       OUTPUT
     end
 

--- a/test/commands/list/favorite/locations_spec.rb
+++ b/test/commands/list/favorite/locations_spec.rb
@@ -120,10 +120,10 @@ FILE
         <<-FILE
 ### Activities:
 - 2015-01-30: Went to a museum with **George Washington Carver**.
-- 2015-01-29: moved to _Paris_.
+- 2015-01-29: Moved to _Paris_.
 - 2015-01-01: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying @food
-- 2014-12-30: Moved to _Atlantis_.
+- 2014-12-30: Went to _Atlantis_.
 - 2014-12-29: Talked to **George Washington Carver** on the phone for an hour.
 
 ### Friends:

--- a/test/commands/list/favorite/locations_spec.rb
+++ b/test/commands/list/favorite/locations_spec.rb
@@ -26,7 +26,7 @@ clean_describe "list favorite locations" do
       <<-FILE
 ### Activities:
 - 2017-01-01: **Grace Hopper** and I went to _Marie's Diner_ for breakfast.
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.

--- a/test/commands/list/locations_spec.rb
+++ b/test/commands/list/locations_spec.rb
@@ -30,6 +30,7 @@ clean_describe "list locations" do
       stdout_only <<-OUTPUT
 Paris
 Atlantis
+Marie's Diner
       OUTPUT
     end
   end

--- a/test/commands/list/locations_spec.rb
+++ b/test/commands/list/locations_spec.rb
@@ -30,7 +30,6 @@ clean_describe "list locations" do
       stdout_only <<-OUTPUT
 Paris
 Atlantis
-Marie's Diner
       OUTPUT
     end
   end

--- a/test/commands/list/locations_spec.rb
+++ b/test/commands/list/locations_spec.rb
@@ -30,7 +30,7 @@ clean_describe "list locations" do
       stdout_only <<-OUTPUT
 Paris
 Atlantis
-Marie's Diner
+Martha's Vineyard
       OUTPUT
     end
   end

--- a/test/commands/rename/friend_spec.rb
+++ b/test/commands/rename/friend_spec.rb
@@ -35,7 +35,7 @@ clean_describe "rename friend" do
     it "updates friend name in activities" do
       value(run_cmd("list activities")[:stdout]).must_equal <<-FILE
 2018-02-06: @science:indoors:agronomy-with-hydroponics: Norman Borlaug and George Washington Carver scored a tour of Atlantis' hydroponics gardens through wetplants@example.org and they took me along.
-2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute. @food
+2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute.
 2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
 2014-12-31: Celebrated the new year in Paris with Marie Curie. @partying
 2014-11-15: Talked to George Washington Carver on the phone for an hour.
@@ -43,7 +43,7 @@ clean_describe "rename friend" do
       subject
       value(run_cmd("list activities")[:stdout]).must_equal <<-FILE
 2018-02-06: @science:indoors:agronomy-with-hydroponics: Norman Borlaug and George Washington scored a tour of Atlantis' hydroponics gardens through wetplants@example.org and they took me along.
-2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute. @food
+2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute.
 2015-01-04: Got lunch with Grace Hopper and George Washington. @food
 2014-12-31: Celebrated the new year in Paris with Marie Curie. @partying
 2014-11-15: Talked to George Washington on the phone for an hour.

--- a/test/commands/rename/friend_spec.rb
+++ b/test/commands/rename/friend_spec.rb
@@ -35,7 +35,7 @@ clean_describe "rename friend" do
     it "updates friend name in activities" do
       value(run_cmd("list activities")[:stdout]).must_equal <<-FILE
 2018-02-06: @science:indoors:agronomy-with-hydroponics: Norman Borlaug and George Washington Carver scored a tour of Atlantis' hydroponics gardens through wetplants@example.org and they took me along.
-2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute.
+2015-11-01: Grace Hopper and I went to Martha's Vineyard. George had to cancel at the last minute.
 2015-01-04: Got lunch with Grace Hopper and George Washington Carver. @food
 2014-12-31: Celebrated the new year in Paris with Marie Curie. @partying
 2014-11-15: Talked to George Washington Carver on the phone for an hour.
@@ -43,7 +43,7 @@ clean_describe "rename friend" do
       subject
       value(run_cmd("list activities")[:stdout]).must_equal <<-FILE
 2018-02-06: @science:indoors:agronomy-with-hydroponics: Norman Borlaug and George Washington scored a tour of Atlantis' hydroponics gardens through wetplants@example.org and they took me along.
-2015-11-01: Grace Hopper and I went to Marie's Diner. George had to cancel at the last minute.
+2015-11-01: Grace Hopper and I went to Martha's Vineyard. George had to cancel at the last minute.
 2015-01-04: Got lunch with Grace Hopper and George Washington. @food
 2014-12-31: Celebrated the new year in Paris with Marie Curie. @partying
 2014-11-15: Talked to George Washington on the phone for an hour.

--- a/test/commands/stats_spec.rb
+++ b/test/commands/stats_spec.rb
@@ -42,7 +42,7 @@ Total time elapsed: 0 days
       stdout_only <<-OUTPUT
 Total activities: 5
 Total friends: 5
-Total locations: 3
+Total locations: 2
 Total notes: 4
 Total tags: 10
 Total time elapsed: 1179 days

--- a/test/commands/stats_spec.rb
+++ b/test/commands/stats_spec.rb
@@ -42,7 +42,7 @@ Total time elapsed: 0 days
       stdout_only <<-OUTPUT
 Total activities: 5
 Total friends: 5
-Total locations: 2
+Total locations: 3
 Total notes: 4
 Total tags: 10
 Total time elapsed: 1179 days

--- a/test/commands/suggest_spec.rb
+++ b/test/commands/suggest_spec.rb
@@ -48,7 +48,7 @@ Close friend: None found
 - 2016-03-01: Met up with **Grace Hopper**.
 - 2016-02-01: Met up with **Grace Hopper**.
 - 2016-01-01: Met up with **Grace Hopper**.
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to Marie's Diner. George had to cancel at the last minute. @food
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
@@ -60,7 +60,6 @@ Close friend: None found
 
 ### Locations:
 - Atlantis
-- Marie's Diner
 - Paris
 FILE
     end

--- a/test/commands/suggest_spec.rb
+++ b/test/commands/suggest_spec.rb
@@ -48,7 +48,7 @@ Close friend: None found
 - 2016-03-01: Met up with **Grace Hopper**.
 - 2016-02-01: Met up with **Grace Hopper**.
 - 2016-01-01: Met up with **Grace Hopper**.
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.

--- a/test/commands/suggest_spec.rb
+++ b/test/commands/suggest_spec.rb
@@ -48,7 +48,7 @@ Close friend: None found
 - 2016-03-01: Met up with **Grace Hopper**.
 - 2016-02-01: Met up with **Grace Hopper**.
 - 2016-01-01: Met up with **Grace Hopper**.
-- 2015-11-01: **Grace Hopper** and I went to Marie's Diner. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
@@ -60,6 +60,7 @@ Close friend: None found
 
 ### Locations:
 - Atlantis
+- Marie's Diner
 - Paris
 FILE
     end

--- a/test/commands/suggest_spec.rb
+++ b/test/commands/suggest_spec.rb
@@ -48,7 +48,7 @@ Close friend: None found
 - 2016-03-01: Met up with **Grace Hopper**.
 - 2016-02-01: Met up with **Grace Hopper**.
 - 2016-01-01: Met up with **Grace Hopper**.
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
+- 2015-11-01: **Grace Hopper** and I went to _Martha's Vineyard_. George had to cancel at the last minute.
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
@@ -60,7 +60,7 @@ Close friend: None found
 
 ### Locations:
 - Atlantis
-- Marie's Diner
+- Martha's Vineyard
 - Paris
 FILE
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -27,7 +27,7 @@ require "friends"
 CONTENT = <<-FILE.freeze
 ### Activities:
 - 2018-02-06: @science:indoors:agronomy-with-hydroponics: **Norman Borlaug** and **George Washington Carver** scored a tour of _Atlantis_' hydroponics gardens through wetplants@example.org and they took me along.
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
+- 2015-11-01: **Grace Hopper** and I went to _Martha's Vineyard_. George had to cancel at the last minute.
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
@@ -47,7 +47,7 @@ CONTENT = <<-FILE.freeze
 
 ### Locations:
 - Atlantis
-- Marie's Diner
+- Martha's Vineyard
 - Paris
 FILE
 
@@ -55,7 +55,7 @@ FILE
 SCRAMBLED_CONTENT = <<-FILE.freeze
 ### Activities:
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
+- 2015-11-01: **Grace Hopper** and I went to _Martha's Vineyard_. George had to cancel at the last minute.
 - 2018-02-06: @science:indoors:agronomy-with-hydroponics: **Norman Borlaug** and **George Washington Carver** scored a tour of _Atlantis_' hydroponics gardens through wetplants@example.org and they took me along.
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
@@ -76,7 +76,7 @@ SCRAMBLED_CONTENT = <<-FILE.freeze
 ### Locations:
 - Paris
 - Atlantis
-- Marie's Diner
+- Martha's Vineyard
 FILE
 
 # Define these methods so they can be referenced in the methods below. They'll be overridden in

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -27,7 +27,7 @@ require "friends"
 CONTENT = <<-FILE.freeze
 ### Activities:
 - 2018-02-06: @science:indoors:agronomy-with-hydroponics: **Norman Borlaug** and **George Washington Carver** scored a tour of _Atlantis_' hydroponics gardens through wetplants@example.org and they took me along.
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
@@ -55,7 +55,7 @@ FILE
 SCRAMBLED_CONTENT = <<-FILE.freeze
 ### Activities:
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute.
 - 2018-02-06: @science:indoors:agronomy-with-hydroponics: **Norman Borlaug** and **George Washington Carver** scored a tour of _Atlantis_' hydroponics gardens through wetplants@example.org and they took me along.
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -27,7 +27,7 @@ require "friends"
 CONTENT = <<-FILE.freeze
 ### Activities:
 - 2018-02-06: @science:indoors:agronomy-with-hydroponics: **Norman Borlaug** and **George Washington Carver** scored a tour of _Atlantis_' hydroponics gardens through wetplants@example.org and they took me along.
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to Marie's Diner. George had to cancel at the last minute. @food
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
@@ -47,7 +47,6 @@ CONTENT = <<-FILE.freeze
 
 ### Locations:
 - Atlantis
-- Marie's Diner
 - Paris
 FILE
 
@@ -55,7 +54,7 @@ FILE
 SCRAMBLED_CONTENT = <<-FILE.freeze
 ### Activities:
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
-- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to Marie's Diner. George had to cancel at the last minute. @food
 - 2018-02-06: @science:indoors:agronomy-with-hydroponics: **Norman Borlaug** and **George Washington Carver** scored a tour of _Atlantis_' hydroponics gardens through wetplants@example.org and they took me along.
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
@@ -76,7 +75,6 @@ SCRAMBLED_CONTENT = <<-FILE.freeze
 ### Locations:
 - Paris
 - Atlantis
-- Marie's Diner
 FILE
 
 # Define these methods so they can be referenced in the methods below. They'll be overridden in

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -27,7 +27,7 @@ require "friends"
 CONTENT = <<-FILE.freeze
 ### Activities:
 - 2018-02-06: @science:indoors:agronomy-with-hydroponics: **Norman Borlaug** and **George Washington Carver** scored a tour of _Atlantis_' hydroponics gardens through wetplants@example.org and they took me along.
-- 2015-11-01: **Grace Hopper** and I went to Marie's Diner. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
@@ -47,6 +47,7 @@ CONTENT = <<-FILE.freeze
 
 ### Locations:
 - Atlantis
+- Marie's Diner
 - Paris
 FILE
 
@@ -54,7 +55,7 @@ FILE
 SCRAMBLED_CONTENT = <<-FILE.freeze
 ### Activities:
 - 2015-01-04: Got lunch with **Grace Hopper** and **George Washington Carver**. @food
-- 2015-11-01: **Grace Hopper** and I went to Marie's Diner. George had to cancel at the last minute. @food
+- 2015-11-01: **Grace Hopper** and I went to _Marie's Diner_. George had to cancel at the last minute. @food
 - 2018-02-06: @science:indoors:agronomy-with-hydroponics: **Norman Borlaug** and **George Washington Carver** scored a tour of _Atlantis_' hydroponics gardens through wetplants@example.org and they took me along.
 - 2014-11-15: Talked to **George Washington Carver** on the phone for an hour.
 - 2014-12-31: Celebrated the new year in _Paris_ with **Marie Curie**. @partying
@@ -75,6 +76,7 @@ SCRAMBLED_CONTENT = <<-FILE.freeze
 ### Locations:
 - Paris
 - Atlantis
+- Marie's Diner
 FILE
 
 # Define these methods so they can be referenced in the methods below. They'll be overridden in


### PR DESCRIPTION
Hi @JacobEvelyn, hope you are having a good Xmas! 🎄

I've made the changes [we discussed](https://github.com/JacobEvelyn/friends/issues/152):
- changed trigger for setting a default location from `moved to _LOCATION_` to `to _LOCATION_`
- I've added functionality (plus tests) to print `Default location set to:  _LOCATION_` to stdout when a `to _LOCATION_` activity is added by the user
- I've updated the readme for setting default locations

While making this PR I came across another instance of us using `to _LOCATION_` in a test where we don't want to set a default location (this is expected as `to _LOCATION_` wasn't used before as a trigger for anything). I removed/amended it, but it did raise the question again of why we are using `to _LOCATION_` as the trigger when its such a commonly used phrase, and why we are not using something more explicit (like `moved to` or `set default location to`). I can easily imagine users writing `I went to Paris for the day` or even `I went to Paris` without wanting to set the default location to Paris.

Just a minor re-push-back from me :) Let me know what you think, happy to discuss changes further 👍 

PS is there a way to run one test a time with minitest? I had a look online, but couldn't find a method that didn't involve installing another gem 🤔  

---

Hi there! Thanks so much for submitting a pull request!

Let's just make sure together that all of these boxes are checked before we
merge this change:

- [x] The code in these changes works correctly.
- [x] Code has tests as appropriate.
- [x] Code has been reviewed by @JacobEvelyn.
- [x] All tests pass on Travis CI.
- [x] Code coverage remains high.
- [x] Rubocop reports no issues on Travis CI.
- [x] The `README.md` file is updated as appropriate.

Don't worry—this list will get checked off in no time!
