### PR TITLE
Add location alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ lots of help), and give feedback! This project is
       - [`add tag`](#add-tag)
       - [`add location`](#add-location)
       - [`add nickname`](#add-nickname)
+      - [`add alias`](#add-alias)
       - [Adding a default location](#adding-a-default-location)
     - [`clean`](#clean)
     - [`graph`](#graph)
@@ -54,6 +55,7 @@ lots of help), and give feedback! This project is
     - `remove`
       - [`remove tag`](#remove-tag)
       - [`remove nickname`](#remove-nickname)
+      - [`remove alias`](#remove-alias)
     - `rename`
       - [`rename friend`](#rename-friend)
       - [`rename location`](#rename-location)
@@ -291,11 +293,13 @@ $ friends add activity Got lunch with Earnest H and Earnest S. in the park. Man,
 Activity added: "2017-05-01: Got lunch with Earnest Hemingway and Earnest Shackleton in the park. Man, I like Earnest Hemingway but really love Earnest Shackleton."
 ```
 
-And locations will be matched as well:
+And locations or their alias will be matched as well:
 
 ```bash
 $ friends add activity Went swimming near atlantis with George.
 Activity added: "2017-01-06: Went swimming near Atlantis with George Washington Carver."
+$ friends add activity Had lunch in NYC with George.
+Activity added: "2017-01-06: Had lunch in New York City with George Washington Carver."
 ```
 
 Tags will be colored if they're provided (though this README can't display
@@ -409,6 +413,15 @@ $ friends add nickname "Grace Hopper" "The Admiral"
 Nickname added: "Grace Hopper (a.k.a. The Admiral)
 $ friends add nickname "Grace Hopper" "Amazing Grace"
 Nickname added: "Grace Hopper (a.k.a. The Admiral a.k.a. Amazing Grace)"
+```
+
+#### `add alias`
+
+```bash
+$ friends add alias "New York City" "NYC"
+Alias added: "New York City (a.k.a. NYC)
+$ friends add alias "New York City" "Big Apple"
+Alias added: "New York City (a.k.a. NYC a.k.a. Big Apple)"
 ```
 
 #### Setting a default location
@@ -874,6 +887,15 @@ Removes a specific nickname from a friend:
 ```bash
 $ friends remove nickname "Grace Hopper" "The Admiral"
 Nickname removed: "Grace Hopper (a.k.a. Amazing Grace)"
+```
+
+#### `remove alias`
+
+Removes an specific alias from a location:
+
+```bash
+$ friends remove alias "New York City" "Big Apple"
+Alias removed: "New York City (a.k.a. NYC)"
 ```
 
 #### `rename friend`

--- a/README.md
+++ b/README.md
@@ -293,12 +293,12 @@ $ friends add activity Got lunch with Earnest H and Earnest S. in the park. Man,
 Activity added: "2017-05-01: Got lunch with Earnest Hemingway and Earnest Shackleton in the park. Man, I like Earnest Hemingway but really love Earnest Shackleton."
 ```
 
-And locations or their alias will be matched as well:
+And locations or their aliases will be matched as well:
 
 ```bash
 $ friends add activity Went swimming near atlantis with George.
 Activity added: "2017-01-06: Went swimming near Atlantis with George Washington Carver."
-$ friends add activity Had lunch in NYC with George.
+$ friends add activity Had lunch in nyc with George.
 Activity added: "2017-01-06: Had lunch in New York City with George Washington Carver."
 ```
 
@@ -891,7 +891,7 @@ Nickname removed: "Grace Hopper (a.k.a. Amazing Grace)"
 
 #### `remove alias`
 
-Removes an specific alias from a location:
+Removes a specific alias from a location:
 
 ```bash
 $ friends remove alias "New York City" "Big Apple"

--- a/lib/friends/commands/add.rb
+++ b/lib/friends/commands/add.rb
@@ -42,9 +42,9 @@ command :add do |add|
 
   add.desc "Adds an alias to a location"
   add.arg_name "LOCATION ALIAS"
-  add.command :alias do |add_location_alias|
-    add_location_alias.action do |_, _, args|
-      @introvert.add_location_alias(name: args.first.to_s.strip, nickname: args[1].to_s.strip)
+  add.command :alias do |add_alias|
+    add_alias.action do |_, _, args|
+      @introvert.add_alias(name: args.first.to_s.strip, nickname: args[1].to_s.strip)
       @dirty = true # Mark the file for cleaning.
     end
   end

--- a/lib/friends/commands/add.rb
+++ b/lib/friends/commands/add.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-desc "Adds a friend (or nickname), activity, note, or location"
+desc "Adds a friend (or nickname), activity, note, or location (or alias)"
 command :add do |add|
   add.desc "Adds a friend"
   add.arg_name "NAME"
@@ -36,6 +36,15 @@ command :add do |add|
   add.command :nickname do |add_nickname|
     add_nickname.action do |_, _, args|
       @introvert.add_nickname(name: args.first.to_s.strip, nickname: args[1].to_s.strip)
+      @dirty = true # Mark the file for cleaning.
+    end
+  end
+
+  add.desc "Adds an alias to a location"
+  add.arg_name "LOCATION ALIAS"
+  add.command :alias do |add_location_alias|
+    add_location_alias.action do |_, _, args|
+      @introvert.add_location_alias(name: args.first.to_s.strip, nickname: args[1].to_s.strip)
       @dirty = true # Mark the file for cleaning.
     end
   end

--- a/lib/friends/commands/list.rb
+++ b/lib/friends/commands/list.rb
@@ -73,8 +73,11 @@ command :list do |list|
 
   list.desc "List all locations"
   list.command :locations do |list_locations|
-    list_locations.action do
-      @introvert.list_locations
+    list_locations.switch [:verbose],
+                          negatable: false,
+                          desc: "Output location aliases"
+    list_locations.action do |_, options|
+      @introvert.list_locations(verbose: options[:verbose])
     end
   end
 

--- a/lib/friends/commands/remove.rb
+++ b/lib/friends/commands/remove.rb
@@ -11,6 +11,15 @@ command :remove do |remove|
     end
   end
 
+  remove.desc "Removes an alias from a location"
+  remove.arg_name "LOCATION ALIAS"
+  remove.command :alias do |remove_location_alias|
+    remove_location_alias.action do |_, _, args|
+      @introvert.remove_location_alias(name: args.first, nickname: args[1])
+      @dirty = true # Mark the file for cleaning.
+    end
+  end
+
   remove.desc "Removes a tag from a friend"
   remove.arg_name "NAME @TAG"
   remove.command :tag do |remove_tag|

--- a/lib/friends/commands/remove.rb
+++ b/lib/friends/commands/remove.rb
@@ -13,9 +13,9 @@ command :remove do |remove|
 
   remove.desc "Removes an alias from a location"
   remove.arg_name "LOCATION ALIAS"
-  remove.command :alias do |remove_location_alias|
-    remove_location_alias.action do |_, _, args|
-      @introvert.remove_location_alias(name: args.first, nickname: args[1])
+  remove.command :alias do |remove_alias|
+    remove_alias.action do |_, _, args|
+      @introvert.remove_alias(name: args.first.to_s.strip, nickname: args[1].to_s.strip)
       @dirty = true # Mark the file for cleaning.
     end
   end

--- a/lib/friends/event.rb
+++ b/lib/friends/event.rb
@@ -183,12 +183,13 @@ module Friends
     # @param introvert [Introvert] used to access internal data structures to
     #   perform location matching
     def highlight_locations(introvert:)
-      introvert.regex_location_map.each do |regex, location_list|
+      introvert.regex_location_map.each do |location, regex_list|
         # If we find a match, replace all instances of the matching text with
         # the location's name. We use single-underscores to indicate locations.
-        description_matches(regex: regex, replace: true, indicator: "_") do
-          location = location_list.first
-          location.name
+        regex_list.each do |regex|
+          description_matches(regex: regex, replace: true, indicator: "_") do
+            location
+          end
         end
       end
     end

--- a/lib/friends/event.rb
+++ b/lib/friends/event.rb
@@ -183,10 +183,11 @@ module Friends
     # @param introvert [Introvert] used to access internal data structures to
     #   perform location matching
     def highlight_locations(introvert:)
-      introvert.regex_location_map.each do |regex, location|
+      introvert.regex_location_map.each do |regex, location_list|
         # If we find a match, replace all instances of the matching text with
         # the location's name. We use single-underscores to indicate locations.
         description_matches(regex: regex, replace: true, indicator: "_") do
+          location = location_list.first
           location.name
         end
       end

--- a/lib/friends/event.rb
+++ b/lib/friends/event.rb
@@ -183,13 +183,11 @@ module Friends
     # @param introvert [Introvert] used to access internal data structures to
     #   perform location matching
     def highlight_locations(introvert:)
-      introvert.regex_location_map.each do |location, regex_list|
+      introvert.regex_location_map.each do |regex, location|
         # If we find a match, replace all instances of the matching text with
         # the location's name. We use single-underscores to indicate locations.
-        regex_list.each do |regex|
-          description_matches(regex: regex, replace: true, indicator: "_") do
-            location
-          end
+        description_matches(regex: regex, replace: true, indicator: "_") do
+          location.name
         end
       end
     end

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -228,7 +228,7 @@ module Friends
       if collision
         raise FriendsError,
               "The location alias \"#{nickname}\" is already taken by "\
-              "\"#{collision.name}\""
+              "\"#{collision}\""
       end
 
       location = thing_with_name_in(:location, name)
@@ -469,16 +469,16 @@ module Friends
     #
     # The returned hash uses the following format:
     #   {
-    #     location.name => [list of locations matching regex]
+    #     /regex/ => location
     #   }
     #
     # This hash is sorted (because Ruby's hashes are ordered) by decreasing
     # regex key length, so the key /Paris, France/ appears before /Paris/.
     #
-    # @return [Hash{String => Array<Regexp>}]
+    # @return [Hash{Regexp => location}]
     def regex_location_map
       @locations.each_with_object({}) do |location, hash|
-        hash[location.name] = location.regexes_for_name
+        location.regexes_for_name.each { |regex| hash[regex] = location }
       end.sort_by { |k, _| -k.to_s.size }.to_h
     end
 

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -330,8 +330,8 @@ module Friends
     end
 
     # List all location names in the friends file.
-    def list_locations
-      @locations.each { |location| @output << location }
+    def list_locations(verbose:)
+      (verbose ? @locations.map(&:to_s) : @locations.map(&:name)).each { |line| @output << line }
     end
 
     # @param from [Array] containing any of: ["activities", "friends", "notes"]

--- a/lib/friends/introvert.rb
+++ b/lib/friends/introvert.rb
@@ -222,7 +222,7 @@ module Friends
       raise FriendsError, "Alias cannot be blank" if nickname.empty?
 
       collision = @locations.find do |loc|
-        loc.name.casecmp?(nickname) || loc.aliases.any? { |a| a.casecmp?(nickname) }
+        loc.name.casecmp(nickname).zero? || loc.aliases.any? { |a| a.casecmp(nickname).zero? }
       end
 
       if collision

--- a/lib/friends/location.rb
+++ b/lib/friends/location.rb
@@ -10,11 +10,13 @@ module Friends
     extend Serializable
 
     SERIALIZATION_PREFIX = "- "
+    # NOTE: nickname is the location alias, but `alias` is a keyword
+    NICKNAME_REFIX = "a.k.a. "
 
     # @return [Regexp] the regex for capturing groups in deserialization
     def self.deserialization_regex
       # Note: this regex must be on one line because whitespace is important
-      /(#{SERIALIZATION_PREFIX})?(?<name>.+)/
+      /(#{SERIALIZATION_PREFIX})?(?<name>[^\(\[@]*[^\(\[@\s])(\s+\(#{NICKNAME_REFIX}(?<nickname_str>.+)\))?/ # rubocop:disable Layout/LineLength
     end
 
     # @return [Regexp] the string of what we expected during deserialization
@@ -23,21 +25,65 @@ module Friends
     end
 
     # @param name [String] the name of the location
-    def initialize(name:)
+    def initialize(name:, nickname_str: nil)
       @name = name
+      @nicknames = nickname_str&.split(" #{NICKNAME_REFIX}") || []
     end
 
     attr_accessor :name
+    attr_reader :nicknames
 
     # @return [String] the file serialization text for the location
     def serialize
-      "#{SERIALIZATION_PREFIX}#{@name}"
+      Paint.unpaint("#{SERIALIZATION_PREFIX}#{self}")
     end
 
-    # @return [Regexp] the regex used to match this location's name in an
-    #   activity description
-    def regex_for_name
-      Friends::RegexBuilder.regex(@name)
+    # @return [String] a string representing the location's name and aliases
+    def to_s
+      unless @nicknames.empty?
+        nickname_str = " (" +
+                       @nicknames.map do |nickname|
+                         "#{NICKNAME_REFIX}#{Paint[nickname, :bold, :yellow]}"
+                       end.join(" ") + ")"
+      end
+
+      "#{Paint[@name, :bold]}#{nickname_str}"
+    end
+
+    # Add a alias, ignoring duplicates.
+    # @param nickname [String] the alias to add
+    def add_alias(nickname)
+      @nicknames << nickname
+      @nicknames.uniq!
+    end
+
+    # @param nickname [String] the alias to remove
+    # @raise [FriendsError] if the location does not have the given alias
+    def remove_alias(nickname)
+      unless @nicknames.include? nickname
+        raise FriendsError, "Alias \"#{nickname}\" not found for \"#{name}\""
+      end
+
+      @nicknames.delete(nickname)
+    end
+
+    # @return [Array] a list of all regexes to match the name in a string
+    # NOTE: Only full names and aliases
+    def regexes_for_name
+      # We generously allow any amount of whitespace between parts of a name.
+      splitter = "\\s+"
+
+      # Create the list of regexes and return it.
+      chunks = name.split(Regexp.new(splitter))
+
+      # First we check aliases
+      [
+        chunks, # Match a full name with the highest priority
+        *@nicknames.map { |n| [n] }
+
+      ].compact.map do |words|
+        Friends::RegexBuilder.regex(words.join(splitter))
+      end
     end
 
     # The number of activities this location is in. This is for internal use

--- a/lib/friends/location.rb
+++ b/lib/friends/location.rb
@@ -10,13 +10,12 @@ module Friends
     extend Serializable
 
     SERIALIZATION_PREFIX = "- "
-    # NOTE: nickname is the location alias, but `alias` is a keyword
-    NICKNAME_REFIX = "a.k.a. "
+    ALIAS_PREFIX = "a.k.a. "
 
     # @return [Regexp] the regex for capturing groups in deserialization
     def self.deserialization_regex
       # Note: this regex must be on one line because whitespace is important
-      /(#{SERIALIZATION_PREFIX})?(?<name>[^\(\[@]*[^\(\[@\s])(\s+\(#{NICKNAME_REFIX}(?<nickname_str>.+)\))?/ # rubocop:disable Layout/LineLength
+      /(#{SERIALIZATION_PREFIX})?(?<name>[^\(]*[^\(\s])(\s+\(#{ALIAS_PREFIX}(?<alias_str>.+)\))?/
     end
 
     # @return [Regexp] the string of what we expected during deserialization
@@ -25,13 +24,13 @@ module Friends
     end
 
     # @param name [String] the name of the location
-    def initialize(name:, nickname_str: nil)
+    def initialize(name:, alias_str: nil)
       @name = name
-      @nicknames = nickname_str&.split(" #{NICKNAME_REFIX}") || []
+      @aliases = alias_str&.split(" #{ALIAS_PREFIX}") || []
     end
 
     attr_accessor :name
-    attr_reader :nicknames
+    attr_reader :aliases
 
     # @return [String] the file serialization text for the location
     def serialize
@@ -40,50 +39,37 @@ module Friends
 
     # @return [String] a string representing the location's name and aliases
     def to_s
-      unless @nicknames.empty?
-        nickname_str = " (" +
-                       @nicknames.map do |nickname|
-                         "#{NICKNAME_REFIX}#{Paint[nickname, :bold, :yellow]}"
-                       end.join(" ") + ")"
+      unless @aliases.empty?
+        alias_str = " (" +
+                    @aliases.map do |nickname|
+                      "#{ALIAS_PREFIX}#{Paint[nickname, :bold, :yellow]}"
+                    end.join(" ") + ")"
       end
 
-      "#{Paint[@name, :bold]}#{nickname_str}"
+      "#{Paint[@name, :bold]}#{alias_str}"
     end
 
-    # Add a alias, ignoring duplicates.
+    # Add an alias, ignoring duplicates.
     # @param nickname [String] the alias to add
     def add_alias(nickname)
-      @nicknames << nickname
-      @nicknames.uniq!
+      @aliases << nickname
+      @aliases.uniq!
     end
 
     # @param nickname [String] the alias to remove
     # @raise [FriendsError] if the location does not have the given alias
     def remove_alias(nickname)
-      unless @nicknames.include? nickname
+      unless @aliases.include? nickname
         raise FriendsError, "Alias \"#{nickname}\" not found for \"#{name}\""
       end
 
-      @nicknames.delete(nickname)
+      @aliases.delete(nickname)
     end
 
     # @return [Array] a list of all regexes to match the name in a string
     # NOTE: Only full names and aliases
     def regexes_for_name
-      # We generously allow any amount of whitespace between parts of a name.
-      splitter = "\\s+"
-
-      # Create the list of regexes and return it.
-      chunks = name.split(Regexp.new(splitter))
-
-      # First we check aliases
-      [
-        chunks, # Match a full name with the highest priority
-        *@nicknames.map { |n| [n] }
-
-      ].compact.map do |words|
-        Friends::RegexBuilder.regex(words.join(splitter))
-      end
+      [name, *@aliases].map { |str| Friends::RegexBuilder.regex(str) }
     end
 
     # The number of activities this location is in. This is for internal use

--- a/test/commands/add/alias_spec.rb
+++ b/test/commands/add/alias_spec.rb
@@ -49,20 +49,20 @@ clean_describe "add alias" do
       end
     end
 
+    describe "when alias is nil" do
+      let(:nickname) { nil }
+
+      it "prints an error message" do
+        stderr_only "Error: Alias cannot be blank"
+      end
+    end
+
     describe "when alias is not blank" do
       let(:nickname) { "'Big Apple'" }
 
       it "adds alias to location" do
         line_changed "- New York City (a.k.a. NYC a.k.a. NY)",
                      "- New York City (a.k.a. NYC a.k.a. NY a.k.a. Big Apple)"
-      end
-
-      it "updates parenthetical in file when friend has existing alias" do
-        run_cmd("add alias 'New York City' 'Gotham'")
-        line_changed(
-          "- New York City (a.k.a. NYC a.k.a. NY a.k.a. Gotham)",
-          "- New York City (a.k.a. NYC a.k.a. NY a.k.a. Gotham a.k.a. Big Apple)"
-        )
       end
 
       it "prints an output message" do

--- a/test/commands/add/alias_spec.rb
+++ b/test/commands/add/alias_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "./test/helper"
+
+clean_describe "add alias" do
+  subject { run_cmd("add alias #{location_name} #{nickname}") }
+
+  let(:content) { CONTENT }
+
+  describe "when location name and alias are blank" do
+    let(:location_name) { nil }
+    let(:nickname) { nil }
+
+    it "prints an error message" do
+      stderr_only 'Error: Expected "[Location Name]" "[Alias]"'
+    end
+  end
+
+  describe "when location name has no matches" do
+    let(:location_name) { "Garbage" }
+    let(:nickname) { "Big Apple Pie" }
+
+    it "prints an error message" do
+      stderr_only 'Error: No location found for "Garbage"'
+    end
+  end
+
+  describe "when location alias has more than one match" do
+    let(:location_name) { "'New York City'" }
+    let(:nickname) { "'Big Apple'" }
+    before do
+      run_cmd("add location Manhattan")
+      run_cmd("add alias Manhattan 'Big Apple'")
+    end
+
+    it "prints an error message" do
+      stderr_only 'Error: The location alias "Big Apple" is already taken by "Manhattan"'
+    end
+  end
+
+  describe "when location name has one match" do
+    let(:location_name) { "'New York City'" }
+
+    describe "when alias is blank" do
+      let(:nickname) { "' '" }
+
+      it "prints an error message" do
+        stderr_only "Error: Alias cannot be blank"
+      end
+    end
+
+    describe "when alias is not blank" do
+      let(:nickname) { "'Big Apple'" }
+
+      it "adds alias to location" do
+        line_changed "- New York City (a.k.a. NYC a.k.a. NY)",
+                     "- New York City (a.k.a. NYC a.k.a. NY a.k.a. Big Apple)"
+      end
+
+      it "updates parenthetical in file when friend has existing alias" do
+        run_cmd("add alias 'New York City' 'Gotham'")
+        line_changed(
+          "- New York City (a.k.a. NYC a.k.a. NY a.k.a. Gotham)",
+          "- New York City (a.k.a. NYC a.k.a. NY a.k.a. Gotham a.k.a. Big Apple)"
+        )
+      end
+
+      it "prints an output message" do
+        stdout_only 'Alias added: "New York City (a.k.a. NYC a.k.a. NY a.k.a. Big Apple)"'
+      end
+    end
+  end
+end

--- a/test/commands/add/alias_spec.rb
+++ b/test/commands/add/alias_spec.rb
@@ -34,7 +34,8 @@ clean_describe "add alias" do
     end
 
     it "prints an error message" do
-      stderr_only 'Error: The location alias "Big Apple" is already taken by "Manhattan"'
+      stderr_only "Error: The location alias "\
+                  '"Big Apple" is already taken by "Manhattan (a.k.a. Big Apple)"'
     end
   end
 

--- a/test/commands/edit_spec.rb
+++ b/test/commands/edit_spec.rb
@@ -134,6 +134,7 @@ Not cleaning file: "#{filename}" ("exit 1 #" did not exit successfully)
 - Atlantis
 - Martha's Vineyard
 - Mysterious Mountains
+- New York City (a.k.a. NYC a.k.a. NY)
 - Paris
       EXPECTED_CONTENT
     end

--- a/test/commands/list/locations_spec.rb
+++ b/test/commands/list/locations_spec.rb
@@ -31,6 +31,7 @@ clean_describe "list locations" do
 Paris
 Atlantis
 Martha's Vineyard
+New York City (a.k.a. NYC a.k.a. NY)
       OUTPUT
     end
   end

--- a/test/commands/list/locations_spec.rb
+++ b/test/commands/list/locations_spec.rb
@@ -31,8 +31,21 @@ clean_describe "list locations" do
 Paris
 Atlantis
 Martha's Vineyard
-New York City (a.k.a. NYC a.k.a. NY)
+New York City
       OUTPUT
+    end
+
+    describe "--verbose" do
+      subject { run_cmd("list locations --verbose") }
+
+      it "lists locations in file order with details" do
+        stdout_only <<-OUTPUT
+Paris
+Atlantis
+Martha's Vineyard
+New York City (a.k.a. NYC a.k.a. NY)
+        OUTPUT
+      end
     end
   end
 end

--- a/test/commands/remove/alias_spec.rb
+++ b/test/commands/remove/alias_spec.rb
@@ -7,6 +7,15 @@ clean_describe "remove alias" do
 
   let(:content) { CONTENT }
 
+  describe "when location and nickname are nil" do
+    let(:location_name) { nil }
+    let(:nickname) { nil }
+
+    it "prints an error message" do
+      stderr_only 'Error: Expected "[Location Name]" "[Alias]"'
+    end
+  end
+
   describe "when location name has no matches" do
     let(:location_name) { "Garbage" }
     let(:nickname) { "'Big Apple Pie'" }
@@ -18,6 +27,13 @@ clean_describe "remove alias" do
 
   describe "when location name has one match" do
     let(:location_name) { "'New York City'" }
+
+    describe "when alias is nil" do
+      let(:nickname) { nil }
+      it "prints an error message" do
+        stderr_only "Error: Alias cannot be blank"
+      end
+    end
 
     describe "when alias is not present on location" do
       let(:nickname) { "Gotham" }
@@ -36,7 +52,7 @@ clean_describe "remove alias" do
         )
       end
 
-      it "removes parenthetical from file when friend has no more nicknames" do
+      it "removes parenthetical from file when location has no more nicknames" do
         run_cmd("remove alias #{location_name} 'NY'")
         line_changed(
           "- New York City (a.k.a. NYC)",

--- a/test/commands/remove/alias_spec.rb
+++ b/test/commands/remove/alias_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "./test/helper"
+
+clean_describe "remove alias" do
+  subject { run_cmd("remove alias #{location_name} #{nickname}") }
+
+  let(:content) { CONTENT }
+
+  describe "when location name has no matches" do
+    let(:location_name) { "Garbage" }
+    let(:nickname) { "'Big Apple Pie'" }
+
+    it "prints an error message" do
+      stderr_only 'Error: No location found for "Garbage"'
+    end
+  end
+
+  describe "when location name has one match" do
+    let(:location_name) { "'New York City'" }
+
+    describe "when alias is not present on location" do
+      let(:nickname) { "Gotham" }
+      it "prints an error message" do
+        stderr_only 'Error: Alias "Gotham" not found for "New York City"'
+      end
+    end
+
+    describe "when alias is present on location" do
+      let(:nickname) { "'NYC'" }
+
+      it "removes alias from location" do
+        line_changed(
+          "- New York City (a.k.a. NYC a.k.a. NY)",
+          "- New York City (a.k.a. NY)"
+        )
+      end
+
+      it "removes parenthetical from file when friend has no more nicknames" do
+        run_cmd("remove alias #{location_name} 'NY'")
+        line_changed(
+          "- New York City (a.k.a. NYC)",
+          "- New York City"
+        )
+      end
+
+      it "prints an output message" do
+        stdout_only 'Alias removed: "New York City (a.k.a. NY)"'
+      end
+    end
+  end
+end

--- a/test/commands/stats_spec.rb
+++ b/test/commands/stats_spec.rb
@@ -42,7 +42,7 @@ Total time elapsed: 0 days
       stdout_only <<-OUTPUT
 Total activities: 5
 Total friends: 5
-Total locations: 3
+Total locations: 4
 Total notes: 4
 Total tags: 10
 Total time elapsed: 1179 days

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -48,6 +48,7 @@ CONTENT = <<-FILE
 ### Locations:
 - Atlantis
 - Martha's Vineyard
+- New York City (a.k.a. NYC a.k.a. NY)
 - Paris
 FILE
 
@@ -77,6 +78,7 @@ SCRAMBLED_CONTENT = <<-FILE
 - Paris
 - Atlantis
 - Martha's Vineyard
+- New York City (a.k.a. NYC a.k.a. NY)
 FILE
 
 # Define these methods so they can be referenced in the methods below. They'll be overridden in


### PR DESCRIPTION
So this is the PR for #242. Hopefully i have not missed something. 
Adds the command `friends add alias`. Quite similar to `friends add nickname`.
Of course it also adds the counter part `friends remove alias`.

I have also added some test cases based on the nickname test cases.

`alias` is unfortunately a keyword in ruby, so i named the variables `nickname` . While function and description using `alias` to match the command. 

---

Hi there! Thanks so much for submitting a pull request!

Let's just make sure together that all of these boxes are checked before we
merge this change:

- [x] The code in these changes works correctly.
- [x] Code has tests as appropriate.
- [x] Code has been reviewed by @JacobEvelyn.
- [x] All tests pass on Travis CI.
- [x] Code coverage remains high.
- [x] Rubocop reports no issues on Travis CI.
- [x] The `README.md` file is updated as appropriate.

Don't worry—this list will get checked off in no time!
