### PR TITLE
Allow emojis and accented characters in names and locations.

### DIFF
--- a/lib/friends/event.rb
+++ b/lib/friends/event.rb
@@ -139,7 +139,7 @@ module Friends
     end
 
     def default_location
-      @default_location ||= @description[/(?<=to _)\w[^_]*(?=_)/]
+      @default_location ||= @description[/(?<=to _)[[\p{L}\p{N}\p{S}_]][^_]*(?=_)/]
     end
 
     # @param friend [Friend] the friend to test
@@ -162,13 +162,13 @@ module Friends
     # Find the names of all friends in this description.
     # @return [Array] list of all friend names in the description
     def friend_names
-      @description.scan(/(?<=\*\*)\w[^\*]*(?=\*\*)/).uniq
+      @description.scan(/(?<=\*\*)[[\p{L}\p{N}\p{S}_]][^\*]*(?=\*\*)/).uniq
     end
 
     # Find the names of all locations in this description.
     # @return [Array] list of all location names in the description
     def description_location_names
-      @description.scan(/(?<=_)\w[^_]*(?=_)/).uniq
+      @description.scan(/(?<=_)[[\p{L}\p{N}\p{S}_]][^_]*(?=_)/).uniq
     end
 
     # @return [Array] list of all location names in either description or implicit_location

--- a/test/add_event_helper.rb
+++ b/test/add_event_helper.rb
@@ -175,6 +175,38 @@ def description_parsing_specs(test_stdout: true)
       end
     end
 
+    describe "when using non-standard characters" do
+      let(:content) do
+        <<-FILE
+### Activities:
+
+### Notes:
+
+### Friends:
+- Émile Zola
+- 💡Edison
+
+### Locations:
+- 📍Paris
+FILE
+      end
+
+      describe "starting with an accent" do
+        let(:description) { "Met with Émile." }
+        it { line_added "- #{date}: Met with **Émile Zola**." }
+      end
+
+      describe "starting with an emoji" do
+        let(:description) { "Lunch with 💡Edison." }
+        it { line_added "- #{date}: Lunch with **💡Edison**." }
+      end
+
+      describe "location starting with an emoji" do
+        let(:description) { "Met in 📍Paris." }
+        it { line_added "- #{date}: Met in _📍Paris_." }
+      end
+    end
+
     describe "when description includes a friend's nickname (case insensitive)" do
       let(:description) { "Lunch with the admiral." }
 


### PR DESCRIPTION
Updated the regex in Event to use Unicode properties (\p{L}, \p{N}, \p{S}). This allows names and locations to start with emojis or accented letters. Added unit tests for emoji and accented name validation.

---

Hi there! Thanks so much for submitting a pull request!

Let's just make sure together that all of these boxes are checked before we
merge this change:

- [✓] The code in these changes works correctly.
- [✓] Code has tests as appropriate.
- [ x] Code has been reviewed by @JacobEvelyn.
- [ x] All tests pass on GitHub.
- [✓] Code coverage remains high.
- [✓] RuboCop reports no issues on GitHub.
- [ x] The `README.md` file is updated as appropriate.

Don't worry—this list will get checked off in no time!

---

I ran the following and there were no issues.
```
bundle exec rubocop lib/friends/event.rb
bundle exec rake test
```
I also added unit tests to cover names that start with emoji.